### PR TITLE
[feature] Add an env var to turn off query caching per table

### DIFF
--- a/lib/redis_memo/memoize_query/cached_select.rb
+++ b/lib/redis_memo/memoize_query/cached_select.rb
@@ -92,6 +92,12 @@ class RedisMemo::MemoizeQuery::CachedSelect
   require_relative 'cached_select/connection_adapter'
   require_relative 'cached_select/statement_cache'
 
+  @@enabled_models = {}
+
+  def self.enabled_models
+    @@enabled_models
+  end
+
   def self.install(connection)
     klass = connection.class
     return if klass.singleton_class < RedisMemo::MemoizeMethod
@@ -318,7 +324,7 @@ class RedisMemo::MemoizeQuery::CachedSelect
   end
 
   def self.extract_binding_relation(table_node)
-    RedisMemo::MemoizeQuery.memoized_models[table_node.try(:name)]
+    enabled_models[table_node.try(:name)]
   end
 
   # Thread locals to exchange information between RedisMemo and ActiveRecord


### PR DESCRIPTION
### Summary
This adds an env var so we can turn off any SQL query caching per table.

Note: The current behavior needs to be updated once we allow memoized methods to set dependencies on Arel: when we disable query caching, the method memorization should probably not be affected.

### Test Plan
- ci
### :books: Related Pull Requests :books:
1. https://github.com/chanzuckerberg/redis-memo/pull/7 [bug fix] Reject unbound select queries
2. https://github.com/chanzuckerberg/redis-memo/pull/5 👉 **Add env var: Turn off query caching per table** 👈 (You are here)
3. https://github.com/chanzuckerberg/redis-memo/pull/6 Drop support for JOIN queries
