### PR TITLE
[bug fix] Drop support for JOIN queries

### DIFF
--- a/lib/redis_memo/memoize_query/cached_select.rb
+++ b/lib/redis_memo/memoize_query/cached_select.rb
@@ -252,6 +252,9 @@ class RedisMemo::MemoizeQuery::CachedSelect
       return unless node.orders.empty?
 
       node.cores.each do |core|
+        # We don't support JOINs
+        return unless core.source.right.empty?
+
         # Should have a WHERE if directly selecting from a table
         source_node = core.source.left
         binding_relation = nil
@@ -307,7 +310,7 @@ class RedisMemo::MemoizeQuery::CachedSelect
       end
 
       bind_params
-    when Arel::Nodes::Join, Arel::Nodes::Union, Arel::Nodes::Or
+    when Arel::Nodes::Union, Arel::Nodes::Or
       [node.left, node.right].each do |child|
         bind_params = bind_params.union(
           extract_bind_params_recurse(child)

--- a/spec/memoize_query_spec.rb
+++ b/spec/memoize_query_spec.rb
@@ -321,9 +321,9 @@ describe RedisMemo::MemoizeQuery do
     end
   end
 
-  it 'memoizes queries with JOIN conditions' do
+  it 'does not memoize queries with JOIN conditions' do
     teacher = Teacher.create!
-    expect_to_use_redis do
+    expect_not_to_use_redis do
       teacher.sites.where(a: 1).to_a
     end
   end


### PR DESCRIPTION
### Summary
We don't really support JOINs well. Currently, it's still possible to have stale cache results if we are selecting from joined tables that do not filter conditions.

This drops the support for JON queries and we can revisit this later.

### Test Plan
- ci
### :books: Related Pull Requests :books:
1. https://github.com/chanzuckerberg/redis-memo/pull/6 👉 **Drop support for JOIN queries** 👈 (You are here)
