### PR TITLE
[fix] Extract dependencies from object reference instead of class

### DIFF
--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -41,11 +41,11 @@ module RedisMemo::MemoizeMethod
 
     alias_method method_name, method_name_with_memo
 
-    @memoized_dependencies ||= Hash.new
-    @memoized_dependencies[method_name] = depends_on
+    @__redis_memo_method_dependencies ||= Hash.new
+    @__redis_memo_method_dependencies[method_name] = depends_on
 
     define_method :dependency_of do |method_name, *method_args|
-      method_depends_on = self.class.instance_variable_get(:@memoized_dependencies)[method_name]
+      method_depends_on = self.class.instance_variable_get(:@__redis_memo_method_dependencies)[method_name]
       unless method_depends_on
         raise(
           RedisMemo::ArgumentError,

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -45,19 +45,15 @@ module RedisMemo::MemoizeMethod
     @memoized_dependencies[method_name] = depends_on
 
     define_method :dependency_of do |method_name, *method_args|
-      self.class.dependency_of(method_name, *method_args)
+      method_depends_on = self.class.instance_variable_get(:@memoized_dependencies)[method_name]
+      unless method_depends_on
+        raise(
+          RedisMemo::ArgumentError,
+          "#{method_name} is not a memoized method"
+        )
+      end
+      RedisMemo::MemoizeMethod.extract_dependencies(self, *method_args, &method_depends_on)
     end
-  end
-
-  def dependency_of(method_name, *method_args)
-    depends_on = @memoized_dependencies[method_name]
-    unless depends_on
-      raise(
-        RedisMemo::ArgumentError,
-        "#{method_name} is not a memoized method"
-      )
-    end
-    RedisMemo::MemoizeMethod.extract_dependencies(self, *method_args, &depends_on)
   end
 
   def self.method_id(ref, method_name)


### PR DESCRIPTION
### Summary
From [here](https://github.com/chanzuckerberg/redis-memo/blob/main/lib/redis_memo/memoize_method.rb#L82), the object reference is used to call the dependency block, not the class. Fix extracting dependencies when calling `dependency_of` to use the object reference as well.

Usually we have something like
```
memoize_method :method |_, *args| do...
end
```
so we don't care about the first argument.
### Testing
Added specs to cover scenario. Without this change, the specs fail with something like
```
     Failure/Error: depends_on RedisMemo::Memoizable.new(id: obj.id, val: x)

     NoMethodError:
       undefined method `id' for #<Class:0x000056241936d420>
```

Specs succeed with this change