### PR TITLE
[feature] Locally cache computation to extract dependencies

### DIFF
--- a/lib/redis_memo/cache.rb
+++ b/lib/redis_memo/cache.rb
@@ -5,8 +5,9 @@ require_relative 'redis'
 class RedisMemo::Cache < ActiveSupport::Cache::RedisCacheStore
   class Rescuable < Exception; end
 
-  THREAD_KEY_LOCAL_CACHE = :__redis_memo_cache_local_cache__
-  THREAD_KEY_RAISE_ERROR = :__redis_memo_cache_raise_error__
+  THREAD_KEY_LOCAL_CACHE            = :__redis_memo_cache_local_cache__
+  THREAD_KEY_LOCAL_DEPENDENCY_CACHE = :__redis_memo_local_cache_dependency_cache__
+  THREAD_KEY_RAISE_ERROR            = :__redis_memo_cache_raise_error__
 
   @@redis = nil
   @@redis_store = nil
@@ -44,12 +45,18 @@ class RedisMemo::Cache < ActiveSupport::Cache::RedisCacheStore
     Thread.current[THREAD_KEY_LOCAL_CACHE]
   end
 
+  def self.local_dependency_cache
+    Thread.current[THREAD_KEY_LOCAL_DEPENDENCY_CACHE]
+  end
+
   class << self
     def with_local_cache(&blk)
       Thread.current[THREAD_KEY_LOCAL_CACHE] = {}
+      Thread.current[THREAD_KEY_LOCAL_DEPENDENCY_CACHE] = {}
       blk.call
     ensure
       Thread.current[THREAD_KEY_LOCAL_CACHE] = nil
+      Thread.current[THREAD_KEY_LOCAL_DEPENDENCY_CACHE] = nil
     end
 
     # RedisCacheStore doesn't read from the local cache before reading from redis

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -41,11 +41,11 @@ module RedisMemo::MemoizeMethod
 
     alias_method method_name, method_name_with_memo
 
-    @memoized_dependencies ||= Hash.new
-    @memoized_dependencies[method_name] = depends_on
+    @__redis_memo_method_dependencies ||= Hash.new
+    @__redis_memo_method_dependencies[method_name] = depends_on
 
     define_method :dependency_of do |method_name, *method_args|
-      method_depends_on = self.class.instance_variable_get(:@memoized_dependencies)[method_name]
+      method_depends_on = self.class.instance_variable_get(:@__redis_memo_method_dependencies)[method_name]
       unless method_depends_on
         raise(
           RedisMemo::ArgumentError,

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -74,7 +74,8 @@ module RedisMemo::MemoizeMethod
   def self.get_or_extract_dependencies(ref, *method_args, &depends_on)
     if RedisMemo::Cache.local_dependency_cache
       RedisMemo::Cache.local_dependency_cache[ref] ||= {}
-      RedisMemo::Cache.local_dependency_cache[ref][method_args] ||= extract_dependencies(ref, *method_args, &depends_on)
+      RedisMemo::Cache.local_dependency_cache[ref][depends_on] ||= {}
+      RedisMemo::Cache.local_dependency_cache[ref][depends_on][method_args] ||= extract_dependencies(ref, *method_args, &depends_on)
     else
       extract_dependencies(ref, *method_args, &depends_on)
     end

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -45,19 +45,15 @@ module RedisMemo::MemoizeMethod
     @memoized_dependencies[method_name] = depends_on
 
     define_method :dependency_of do |method_name, *method_args|
-      self.class.dependency_of(method_name, *method_args)
+      method_depends_on = self.class.instance_variable_get(:@memoized_dependencies)[method_name]
+      unless method_depends_on
+        raise(
+          RedisMemo::ArgumentError,
+          "#{method_name} is not a memoized method"
+        )
+      end
+      RedisMemo::MemoizeMethod.extract_dependencies(self, *method_args, &method_depends_on)
     end
-  end
-
-  def dependency_of(method_name, *method_args)
-    depends_on = @memoized_dependencies[method_name]
-    unless depends_on
-      raise(
-        RedisMemo::ArgumentError,
-        "#{method_name} is not a memoized method"
-      )
-    end
-    RedisMemo::MemoizeMethod.extract_dependencies(self, *method_args, &depends_on)
   end
 
   def self.method_id(ref, method_name)

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -52,7 +52,7 @@ module RedisMemo::MemoizeMethod
           "#{method_name} is not a memoized method"
         )
       end
-      RedisMemo::MemoizeMethod.extract_dependencies(self, *method_args, &method_depends_on)
+      RedisMemo::MemoizeMethod.get_or_extract_dependencies(self, *method_args, &method_depends_on)
     end
   end
 
@@ -71,11 +71,20 @@ module RedisMemo::MemoizeMethod
     dependency
   end
 
+  def self.get_or_extract_dependencies(ref, *method_args, &depends_on)
+    if RedisMemo::Cache.local_dependency_cache
+      RedisMemo::Cache.local_dependency_cache[ref] ||= {}
+      RedisMemo::Cache.local_dependency_cache[ref][method_args] ||= extract_dependencies(ref, *method_args, &depends_on)
+    else
+      extract_dependencies(ref, *method_args, &depends_on)
+    end
+  end
+
   def self.method_cache_keys(future_contexts)
     memos = Array.new(future_contexts.size)
     future_contexts.each_with_index do |(ref, _, method_args, depends_on), i|
       if depends_on
-        dependency = extract_dependencies(ref, *method_args, &depends_on)
+        dependency = get_or_extract_dependencies(ref, *method_args, &depends_on)
         memos[i] = dependency.memos
       end
     end

--- a/spec/memoizable/dependency_spec.rb
+++ b/spec/memoizable/dependency_spec.rb
@@ -151,8 +151,8 @@ describe RedisMemo::Memoizable::Invalidation do
       it 'locally caches computation to extract dependencies' do
         RedisMemo::Cache.with_local_cache do
           expect(RedisMemo::MemoizeMethod).to receive(:extract_dependencies).twice.and_call_original
-          5.times { obj.calc(val) }
           5.times { obj.calc_b_c(val) }
+          5.times { obj.calc(val) }
         end
       end
     end

--- a/spec/memoizable/dependency_spec.rb
+++ b/spec/memoizable/dependency_spec.rb
@@ -99,7 +99,7 @@ describe RedisMemo::Memoizable::Invalidation do
       }.to change { obj.calc_count }.by(1)
     end
 
-    it 'pulls in dependencies defined by other methods' do
+    context 'with dependencies of other methods' do
       klass = Class.new do
         extend RedisMemo::MemoizeMethod
   
@@ -129,21 +129,31 @@ describe RedisMemo::Memoizable::Invalidation do
           depends_on RedisMemo::Memoizable.new(val: x)
         end
       end
-
       obj = klass.new(:e)
       obj.calc_count = 0
       val = 0
-      [
-        RedisMemoSpecDAG.a(val),
-        RedisMemoSpecDAG.b(val),
-        RedisMemoSpecDAG.c(val),
-        RedisMemo::Memoizable.new(id: obj.id, val: val),
-        RedisMemo::Memoizable.new(val: val)
-      ].each do |memo|
-        expect {
-          RedisMemo::Memoizable.invalidate([memo])
+
+      it 'pulls in dependencies defined by other methods' do
+        [
+          RedisMemoSpecDAG.a(val),
+          RedisMemoSpecDAG.b(val),
+          RedisMemoSpecDAG.c(val),
+          RedisMemo::Memoizable.new(id: obj.id, val: val),
+          RedisMemo::Memoizable.new(val: val)
+        ].each do |memo|
+          expect {
+            RedisMemo::Memoizable.invalidate([memo])
+            5.times { obj.calc(val) }
+          }.to change { obj.calc_count }.by(1)
+        end
+      end
+
+      it 'locally caches computation to extract dependencies' do
+        RedisMemo::Cache.with_local_cache do
+          expect(RedisMemo::MemoizeMethod).to receive(:extract_dependencies).twice.and_call_original
           5.times { obj.calc(val) }
-        }.to change { obj.calc_count }.by(1)
+          5.times { obj.calc_b_c(val) }
+        end
       end
     end
 


### PR DESCRIPTION
### Summary
A follow up to [this](https://github.com/chanzuckerberg/redis-memo/pull/8#discussion_r568833999) comment, add a request level cache for caching the recursive computation to extract dependencies.
### Testing
Added specs for the new scenario