### PR TITLE
[feature] Support overwriting uuid generation

### DIFF
--- a/lib/redis_memo.rb
+++ b/lib/redis_memo.rb
@@ -2,6 +2,7 @@
 require 'active_support/all'
 require 'digest'
 require 'json'
+require 'securerandom'
 
 module RedisMemo
   require 'redis_memo/memoize_method'
@@ -23,6 +24,10 @@ module RedisMemo
 
   def self.checksum(serialized)
     Digest::SHA1.base64digest(serialized)
+  end
+
+  def self.uuid
+    SecureRandom.uuid
   end
 
   def self.deep_sort_hash(orig_hash)

--- a/lib/redis_memo/memoizable.rb
+++ b/lib/redis_memo/memoizable.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'securerandom'
 
 class RedisMemo::Memoizable
   require_relative 'memoizable/dependency'
@@ -52,7 +51,7 @@ class RedisMemo::Memoizable
       cache_key = instance.cache_key
       RedisMemo::Memoizable::Invalidation.bump_version_later(
         cache_key,
-        SecureRandom.uuid,
+        RedisMemo.uuid,
       )
     end
 
@@ -96,7 +95,7 @@ class RedisMemo::Memoizable
         # cached result.
         need_to_bump_versions = true
 
-        new_version = SecureRandom.uuid
+        new_version = RedisMemo.uuid
         RedisMemo::Memoizable::Invalidation.bump_version_later(
           key,
           new_version,

--- a/lib/redis_memo/memoizable/invalidation.rb
+++ b/lib/redis_memo/memoizable/invalidation.rb
@@ -96,7 +96,7 @@ module RedisMemo::Memoizable::Invalidation
       RedisMemo::Cache.redis.eval(
         LUA_BUMP_VERSION,
         keys: [cache_key],
-        argv: [previous_version, version, SecureRandom.uuid, ttl],
+        argv: [previous_version, version, RedisMemo.uuid, ttl],
       )
     end
     RedisMemo::DefaultOptions.logger&.info("[performed] Bump memo key #{cache_key}")


### PR DESCRIPTION
### Summary
In spec, or some other use cases, people might want to overwrite the existing UUID generation behavior in RedisMemo. This PR adds a common entry point for the UUID generation for people to overwrite.

### Test Plan
- ci