### PR TITLE
[feature] Allow using an ActiveRecord::Relation as a dependency

### DIFF
--- a/lib/redis_memo/memoize_query/cached_select.rb
+++ b/lib/redis_memo/memoize_query/cached_select.rb
@@ -187,6 +187,19 @@ class RedisMemo::MemoizeQuery::CachedSelect
     Thread.current[THREAD_KEY_AREL_BIND_PARAMS] = nil
   end
 
+  def self.with_new_query_context
+    prev_arel = Thread.current[THREAD_KEY_AREL]
+    prev_substitutes = Thread.current[THREAD_KEY_SUBSTITUTES]
+    prev_bind_params = Thread.current[THREAD_KEY_AREL_BIND_PARAMS]
+    RedisMemo::MemoizeQuery::CachedSelect.reset_current_query
+
+    yield
+  ensure
+    Thread.current[THREAD_KEY_AREL] = prev_arel
+    Thread.current[THREAD_KEY_SUBSTITUTES] = prev_substitutes
+    Thread.current[THREAD_KEY_AREL_BIND_PARAMS] = prev_bind_params
+  end
+
   private
 
   # A pre-order Depth First Search


### PR DESCRIPTION
### Summary
Enable using an ActiveRecord::Relation object as a dependency of a memoized method. Do this by:
- Adding a new case for `ActiveRecord::Relation` while extracting dependencies in `RedisMemo::Dependency.depends_on`
- Re-use the logic to extract bind params while executing a query. (Is it safe to also hijack the thread local variables that are shared between activerecord/redismemo in this case?)

Follow up:
- Do we want to be able to specify queries from finder methods? e.g. `.find(), .pluck()`, which immediately execute the query instead of lazy loading it like ActiveRecord::Relation?


### Testing
Added specs