### PR TITLE
[feature] Optimize activerecord-import cache invalidation

### DIFF
--- a/lib/redis_memo/memoize_query.rb
+++ b/lib/redis_memo/memoize_query.rb
@@ -103,6 +103,10 @@ if defined?(ActiveRecord)
     end
 
     def self.invalidate(record)
+      RedisMemo::Memoizable.invalidate(to_memos(record))
+    end
+
+    def self.to_memos(record)
       # Invalidate memos with current values
       memos_to_invalidate = memoized_columns(record.class).map do |columns|
         props = {}
@@ -137,7 +141,7 @@ if defined?(ActiveRecord)
         end
       end
 
-      RedisMemo::Memoizable.invalidate(memos_to_invalidate)
+      memos_to_invalidate
     end
   end
 end

--- a/redis-memo.gemspec
+++ b/redis-memo.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'redis', '~> 4'
 
   s.add_development_dependency 'activerecord', '~> 5.2'
+  s.add_development_dependency 'activerecord-import'
   s.add_development_dependency 'codecov'
   s.add_development_dependency 'database_cleaner-active_record'
   s.add_development_dependency 'pg'


### PR DESCRIPTION
### Summary
When using PostgreSQL, we can reduce the number of records we have to invalidate for each import.

Postgres supports "RETURNING id", so we can easily get the result set back and perform invalidation on the created result set.

We also need to send another query before the import in case it's an UPSERT operation. In this case, we'd need to query all the values before updating so we can properly invalidate the cache.

As a result, we are now sending two extra SELECT SQL queries for each import operation. This should not be an issue since it only makes the import slightly slower -- the result set of both queries is strongly correlated with the size of the records to import (cannot be too big).

### Test Plan
- added test cases
- ci