### PR TITLE
[feature] Trace invalidation key and enqueue_to_finish duration

### DIFF
--- a/lib/redis_memo/after_commit.rb
+++ b/lib/redis_memo/after_commit.rb
@@ -66,7 +66,12 @@ class RedisMemo::AfterCommit
       @@pending_memo_versions.each do |key, version|
         invalidation_queue =
           RedisMemo::Memoizable::Invalidation.class_variable_get(:@@invalidation_queue)
-        invalidation_queue << [key, version, @@previous_memo_versions[key]]
+
+        invalidation_queue << RedisMemo::Memoizable::Invalidation::Task.new(
+          key,
+          version,
+          @@previous_memo_versions[key],
+        )
       end
 
       RedisMemo::Memoizable::Invalidation.drain_invalidation_queue

--- a/lib/redis_memo/tracer.rb
+++ b/lib/redis_memo/tracer.rb
@@ -11,13 +11,15 @@ class RedisMemo::Tracer
     end
   end
 
-  def self.set_tag(cache_hit:)
+  def self.set_tag(**tags)
     tracer = RedisMemo::DefaultOptions.tracer
     return if tracer.nil? || !tracer.respond_to?(:active_span)
 
     active_span = tracer.active_span
     return if !active_span.respond_to?(:set_tag)
 
-    active_span.set_tag('cache_hit', cache_hit)
+    tags.each do |name, value|
+      active_span.set_tag(name, value)
+    end
   end
 end


### PR DESCRIPTION
### Summary
This adds more visibility to:
- how long each invalidation request has spent in the invalidation queue
- we can see the operation history given a memoizable (hashed). To debug, we first need to generate the same key on the client-side. We do this to avoid sending PII to 3rd party tracing service such as datadog

### Test Plan
- this has been covered by test cases
- ci
