### PR TITLE
[rails 6] Explictly set raw option when reading versions

### DIFF
--- a/lib/redis_memo/cache.rb
+++ b/lib/redis_memo/cache.rb
@@ -60,7 +60,7 @@ class RedisMemo::Cache < ActiveSupport::Cache::RedisCacheStore
     end
 
     # RedisCacheStore doesn't read from the local cache before reading from redis
-    def read_multi(*keys, raise_error: false)
+    def read_multi(*keys, raw: false, raise_error: false)
       return {} if keys.empty?
 
       Thread.current[THREAD_KEY_RAISE_ERROR] = raise_error
@@ -71,7 +71,7 @@ class RedisMemo::Cache < ActiveSupport::Cache::RedisCacheStore
       keys_to_fetch -= local_entries.keys unless local_entries.empty?
       return local_entries if keys_to_fetch.empty?
 
-      remote_entries = redis_store.read_multi(*keys_to_fetch)
+      remote_entries = redis_store.read_multi(*keys_to_fetch, raw: raw)
       local_cache&.merge!(remote_entries)
 
       if local_entries.empty?

--- a/lib/redis_memo/memoizable.rb
+++ b/lib/redis_memo/memoizable.rb
@@ -82,7 +82,11 @@ class RedisMemo::Memoizable
       if keys_to_fetch.empty?
         {}
       else
-        RedisMemo::Cache.read_multi(*keys_to_fetch, raise_error: true)
+        RedisMemo::Cache.read_multi(
+          *keys_to_fetch,
+          raw: true,
+          raise_error: true,
+        )
       end
     memo_versions.merge!(cached_versions) unless cached_versions.empty?
 

--- a/lib/redis_memo/memoizable/invalidation.rb
+++ b/lib/redis_memo/memoizable/invalidation.rb
@@ -56,7 +56,10 @@ module RedisMemo::Memoizable::Invalidation
       # Fill an expected previous version so the later calculation results
       # based on this version can still be rolled out if this version
       # does not change
-      previous_version ||= RedisMemo::Cache.read_multi(key)[key]
+      previous_version ||= RedisMemo::Cache.read_multi(
+        key,
+        raw: true,
+      )[key]
     end
 
     local_cache&.send(:[]=, key, version)

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -79,7 +79,13 @@ describe RedisMemo::Cache do
 
   it 'raises an error if configured' do
     allow(RedisMemo::DefaultOptions).to receive(:async) do
-      proc { |&blk| Thread.new { blk.call } }
+      proc do |&blk|
+        Thread.new do
+          # Do not print out stack traces
+          Thread.current.report_on_exception = false
+          blk.call
+        end
+      end
     end
     allow_any_instance_of(Redis).to receive(:mget) do
       raise ::Redis::BaseConnectionError


### PR DESCRIPTION
### Summary
In Rails 6, we'd need to pass in a `raw: true` for the RedisCacheStore to properly deserialize the raw version values we set.

### Test Plan
- ci
- tested locally with Rails 6