### PR TITLE
[rails 6] Update dependent gem versions

### DIFF
--- a/redis-memo.gemspec
+++ b/redis-memo.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ['>= 2.5.0']
 
-  s.add_dependency 'activesupport', '~> 5.2'
-  s.add_dependency 'redis', '~> 4'
+  s.add_dependency 'activesupport', '>= 5.2'
+  s.add_dependency 'redis', '>= 4.0.1'
 
-  s.add_development_dependency 'activerecord', '~> 5.2'
+  s.add_development_dependency 'activerecord', '>= 5.2'
   s.add_development_dependency 'activerecord-import'
   s.add_development_dependency 'codecov'
   s.add_development_dependency 'database_cleaner-active_record'


### PR DESCRIPTION
### Summary
With this PR, we will start to use activerecord 6 for ci testing.

In the following PRs, I will configure the CI to test with multiple activerecord versions.

### Test Plan
- ci