### PR TITLE
[feature] Support memoizing a method conditionally

### DIFF
--- a/lib/redis_memo.rb
+++ b/lib/redis_memo.rb
@@ -97,4 +97,5 @@ module RedisMemo
   # @todo Move errors to a separate file errors.rb
   class ArgumentError < ::ArgumentError; end
   class RuntimeError < ::RuntimeError; end
+  class WithoutMemoization < Exception; end
 end

--- a/lib/redis_memo/future.rb
+++ b/lib/redis_memo/future.rb
@@ -9,14 +9,14 @@ class RedisMemo::Future
     ref,
     method_id,
     method_args,
-    depends_on,
+    dependent_memos,
     cache_options,
     method_name_without_memo
   )
     @ref = ref
     @method_id = method_id
     @method_args = method_args
-    @depends_on = depends_on
+    @dependent_memos = dependent_memos
     @cache_options = cache_options
     @method_name_without_memo = method_name_without_memo
     @method_cache_key = nil
@@ -28,7 +28,7 @@ class RedisMemo::Future
   end
 
   def context
-    [@ref, @method_id, @method_args, @depends_on]
+    [@ref, @method_id, @method_args, @dependent_memos]
   end
 
   def method_cache_key

--- a/lib/redis_memo/future.rb
+++ b/lib/redis_memo/future.rb
@@ -28,7 +28,7 @@ class RedisMemo::Future
   end
 
   def context
-    [@ref, @method_id, @method_args, @dependent_memos]
+    [@method_id, @method_args, @dependent_memos]
   end
 
   def method_cache_key

--- a/lib/redis_memo/memoizable/dependency.rb
+++ b/lib/redis_memo/memoizable/dependency.rb
@@ -51,8 +51,8 @@ class RedisMemo::Memoizable::Dependency
       RedisMemo::MemoizeQuery::CachedSelect.current_query = relation.arel
       is_query_cached = RedisMemo::MemoizeQuery::CachedSelect.extract_bind_params(query)
         raise(
-          RedisMemo::ArgumentError,
-          "Invalid Arel dependency. Query is not enabled for RedisMemo caching."
+          RedisMemo::WithoutMemoization,
+          "Arel query is not cached using RedisMemo."
         ) unless is_query_cached
         extracted_dependency = connection.dependency_of(:exec_query, query, nil, binds)
     end

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -43,6 +43,8 @@ module RedisMemo::MemoizeMethod
       end
 
       future.execute
+    rescue RedisMemo::WithoutMemoization
+      send(method_name_without_memo, *args)
     end
 
     alias_method method_name, method_name_with_memo

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -91,14 +91,14 @@ module RedisMemo::MemoizeMethod
 
   def self.method_cache_keys(future_contexts)
     memos = Array.new(future_contexts.size)
-    future_contexts.each_with_index do |(_, _, _, dependent_memos), i|
+    future_contexts.each_with_index do |(_, _, dependent_memos), i|
       memos[i] = dependent_memos
     end
 
     j = 0
     memo_checksums = RedisMemo::Memoizable.checksums(memos.compact)
     method_cache_key_versions = Array.new(future_contexts.size)
-    future_contexts.each_with_index do |(_, method_id, method_args, _), i|
+    future_contexts.each_with_index do |(method_id, method_args, _), i|
       if memos[i]
         method_cache_key_versions[i] = [method_id, memo_checksums[j]]
         j += 1

--- a/spec/memoizable/dependency_spec.rb
+++ b/spec/memoizable/dependency_spec.rb
@@ -291,7 +291,7 @@ describe RedisMemo::Memoizable::Invalidation do
       }.to change { record.calc_count }.by(1)
     end
 
-    it 'Falls back to the uncached method when a dependent arel query is not memoized' do
+    it 'falls back to the uncached method when a dependent arel query is not memoized' do
       record = SpecModel.create!(a: 1, not_memoized: 1)
       record.calc_count = 0
       record.class_eval do

--- a/spec/memoizable/dependency_spec.rb
+++ b/spec/memoizable/dependency_spec.rb
@@ -291,8 +291,9 @@ describe RedisMemo::Memoizable::Invalidation do
       }.to change { record.calc_count }.by(1)
     end
 
-    it 'raises an error when the arel is not memoized' do
+    it 'Falls back to the uncached method when a dependent arel query is not memoized' do
       record = SpecModel.create!(a: 1, not_memoized: 1)
+      record.calc_count = 0
       record.class_eval do
         def calc_2
           @calc_count += 2
@@ -303,8 +304,8 @@ describe RedisMemo::Memoizable::Invalidation do
         end
       end
       expect {
-        record.calc_2
-      }.to raise_error(RedisMemo::ArgumentError)
+        5.times { record.calc_2 }
+      }.to change { record.calc_count }.by(10)
     end
   end
 end


### PR DESCRIPTION
### Summary
Support the following use case to allow clients to raise an error `RedisMemo::WithoutMemoization` if they don't want to memoize a method based on certain method args.
```
def method(without_memoization: false)
end

memoize_method :method do |_, without_memoization|
    raise RedisMemo::WithoutMemoization if without_memoization
    depends_on ....
  end
end
``` 
- Change the behavior so that instead of throwing an error when an Arel dependency isn't memoized, fall back to calling the original method without memoization.
- Also refactor a bit so that we extract dependencies before creating the future.
### Testing
Existing specs pass, also added a few specs to test this behavior.