### PR TITLE
[feature] Add bulk_operations invalidation limit

### DIFF
--- a/lib/redis_memo/memoize_query.rb
+++ b/lib/redis_memo/memoize_query.rb
@@ -102,8 +102,10 @@ if defined?(ActiveRecord)
       end
     end
 
-    def self.invalidate(record)
-      RedisMemo::Memoizable.invalidate(to_memos(record))
+    def self.invalidate(*records)
+      RedisMemo::Memoizable.invalidate(
+        records.map { |record| to_memos(record) }.flatten,
+      )
     end
 
     def self.to_memos(record)

--- a/lib/redis_memo/options.rb
+++ b/lib/redis_memo/options.rb
@@ -74,13 +74,14 @@ class RedisMemo::Options
   end
 
   attr_accessor :async
+  attr_accessor :bulk_operations_invalidation_limit
+  attr_accessor :cache_out_of_date_handler
+  attr_accessor :cache_validation_sampler
   attr_accessor :compress
   attr_accessor :compress_threshold
-  attr_accessor :redis_error_handler
-  attr_accessor :expires_in
-  attr_accessor :cache_validation_sampler
-  attr_accessor :cache_out_of_date_handler
   attr_accessor :connection_pool
+  attr_accessor :expires_in
+  attr_accessor :redis_error_handler
 
   attr_writer :global_cache_key_version
   attr_writer :redis


### PR DESCRIPTION
### Summary
This adds a limit to the number of records we would select from the database. Previously I thought we're selecting by uniq_by columns -- I was confused and wrong. We're actually selecting by the columns_to_update so the number of records can be super big.

This PR:
- Sets such limit. If we're going to load many records; simply invalidate everything
- We only care about the columns_to_update if they overlap with the columns we're memorizing
- Adds monitoring

### Test Plan
- ci
 