### PR TITLE
[fix] Create new clients for connection_pool

### DIFF
--- a/lib/redis_memo/cache.rb
+++ b/lib/redis_memo/cache.rb
@@ -27,10 +27,7 @@ class RedisMemo::Cache < ActiveSupport::Cache::RedisCacheStore
   def self.redis
     @@redis ||=
       if RedisMemo::DefaultOptions.connection_pool
-        RedisMemo::ConnectionPool.new(
-          RedisMemo::DefaultOptions.redis,
-          **RedisMemo::DefaultOptions.connection_pool,
-        )
+        RedisMemo::ConnectionPool.new(**RedisMemo::DefaultOptions.connection_pool)
       else
         RedisMemo::DefaultOptions.redis
       end

--- a/lib/redis_memo/connection_pool.rb
+++ b/lib/redis_memo/connection_pool.rb
@@ -3,8 +3,11 @@ require 'connection_pool'
 require_relative 'redis'
 
 class RedisMemo::ConnectionPool
-  def initialize(redis, **options)
-    @connection_pool = ::ConnectionPool.new(**options) { redis }
+  def initialize(**options)
+    @connection_pool = ::ConnectionPool.new(**options) do
+      # Construct a new client every time the block gets called
+      RedisMemo::Redis.new(RedisMemo::DefaultOptions.redis_config)
+    end
   end
 
   # Avoid method_missing when possible for better performance

--- a/lib/redis_memo/memoizable/invalidation.rb
+++ b/lib/redis_memo/memoizable/invalidation.rb
@@ -126,7 +126,8 @@ module RedisMemo::Memoizable::Invalidation
       task = @@invalidation_queue.pop
       begin
         bump_version(task)
-      rescue SignalException, Redis::BaseConnectionError
+      rescue SignalException, Redis::BaseConnectionError,
+             ::ConnectionPool::TimeoutError
         retry_queue << task
       end
     end

--- a/lib/redis_memo/options.rb
+++ b/lib/redis_memo/options.rb
@@ -13,7 +13,7 @@ class RedisMemo::Options
   )
     @compress = compress.nil? ? true : compress
     @compress_threshold = compress_threshold || 1.kilobyte
-    @redis = redis
+    @redis_config = redis
     @redis_client = nil
     @redis_error_handler = redis_error_handler
     @tracer = tracer
@@ -22,20 +22,18 @@ class RedisMemo::Options
     @expires_in = expires_in
   end
 
-  def redis(&blk)
-    if blk.nil?
-      return @redis_client if @redis_client.is_a?(RedisMemo::Redis)
+  def redis
+    @redis_client ||= RedisMemo::Redis.new(redis_config)
+  end
 
-      if @redis.respond_to?(:call)
-        @redis_client = RedisMemo::Redis.new(@redis.call)
-      elsif @redis
-        @redis_client = RedisMemo::Redis.new(@redis)
-      else
-        @redis_client = RedisMemo::Redis.new
-      end
-    else
-      @redis = blk
-    end
+  def redis_config
+    @redis_config || {}
+  end
+
+  def redis=(config)
+    @redis_config = config
+    @redis_client = nil
+    redis
   end
 
   def tracer(&blk)
@@ -84,7 +82,6 @@ class RedisMemo::Options
   attr_accessor :redis_error_handler
 
   attr_writer :global_cache_key_version
-  attr_writer :redis
   attr_writer :tracer
   attr_writer :logger
 end

--- a/redis-memo.gemspec
+++ b/redis-memo.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport', '>= 5.2'
   s.add_dependency 'redis', '>= 4.0.1'
-  s.add_dependency 'connection_pool'
+  s.add_dependency 'connection_pool', '>= 2.2.3'
 
   s.add_development_dependency 'activerecord', '>= 5.2'
   s.add_development_dependency 'activerecord-import'

--- a/spec/connection_pool_spec.rb
+++ b/spec/connection_pool_spec.rb
@@ -1,9 +1,6 @@
 describe RedisMemo::ConnectionPool do
   it 'delegates methods' do
-    redis = RedisMemo::ConnectionPool.new(
-      RedisMemo::DefaultOptions.redis,
-      size: 5,
-    )
+    redis = RedisMemo::ConnectionPool.new(size: 5)
 
     expect(redis.ping).to eq(['PONG'])
     expect(redis.get('a')).to be_nil


### PR DESCRIPTION
### Summary
With https://github.com/mperham/connection_pool, each time the block is called, it is supposed to create a new client object.