### PR TITLE
[fix] Avoid mutating default options when building Redis client

### DIFF
--- a/lib/redis_memo/redis.rb
+++ b/lib/redis_memo/redis.rb
@@ -31,7 +31,8 @@ class RedisMemo::Redis < Redis::Distributed
   end
 
   class WithReplicas < ::Redis
-    def initialize(options)
+    def initialize(orig_options)
+      options = orig_options.dup
       primary_option = options.shift
       @replicas = options.map do |option|
         option[:logger] ||= RedisMemo::DefaultOptions.logger


### PR DESCRIPTION
### Summary
Since we're calling `shift` on the options, the default options are altered whenever we create a new Redis client.

This fixes the issue.