### PR TITLE
[feature] Optimize the local dependency cache based on dependency block args

### DIFF
--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -108,11 +108,11 @@ module RedisMemo::MemoizeMethod
       depends_on_args = [ref] + args
       depends_on_parameters = depends_on.parameters.clone
       # A double splat should always be the last parameter
-      if depends_on_parameters[-1][0] == :keyrest && depends_on_args[-1].is_a?(Hash)
+      if depends_on_parameters[-1].size == 2 && depends_on_parameters[-1][0] == :keyrest && depends_on_args[-1].is_a?(Hash)
         mapped_args[depends_on_parameters.pop[1]] = depends_on_args.pop
       end
       depends_on_parameters.each_with_index do |param, i|
-        unless param[1] == :_ || param[1].nil?
+        unless param.size != 2 || param[1] == :_
           # If it's a single splat, take the rest of the arguments
           if param[0] == :rest
             mapped_args[param[1]] = depends_on_args[i..-1]

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -108,7 +108,7 @@ module RedisMemo::MemoizeMethod
     positional_args = []
     kwargs = {}
     named_rest = false
-    depends_on_args = [ref] + deep_copy(args)
+    depends_on_args = [ref] + args
     options = depends_on_args.extract_options!
 
     depends_on.parameters.each_with_index do |param, i|
@@ -121,7 +121,7 @@ module RedisMemo::MemoizeMethod
           named_rest = true
           positional_args.concat(depends_on_args[i..-1])
         when :key, :keyreq
-          kwargs[param.last] = options.delete(param.last)
+          kwargs[param.last] = options[param.last]
         when :keyrest
           kwargs.merge!(options)
         else
@@ -178,11 +178,5 @@ module RedisMemo::MemoizeMethod
     end
   rescue RedisMemo::Cache::Rescuable
     nil
-  end
-
-  private
-
-  def self.deep_copy(o)
-    Marshal.load(Marshal.dump(o))
   end
 end

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -158,7 +158,7 @@ module RedisMemo::MemoizeMethod
       positional_args
     end
   end
-
+private
   def self.is_named?(param)
     param.size == 2 && param.last != :_
   end

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -108,8 +108,8 @@ module RedisMemo::MemoizeMethod
     positional_args = []
     kwargs = {}
     named_rest = false
-    depends_on_args = [ref] + args
-    options = depends_on_args.extract_options!&.clone
+    depends_on_args = [ref] + deep_copy(args)
+    options = depends_on_args.extract_options!
 
     depends_on.parameters.each_with_index do |param, i|
       unless param.size != 2 || param.last == :_
@@ -178,5 +178,11 @@ module RedisMemo::MemoizeMethod
     end
   rescue RedisMemo::Cache::Rescuable
     nil
+  end
+
+  private
+
+  def self.deep_copy(o)
+    Marshal.load(Marshal.dump(o))
   end
 end

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -107,35 +107,60 @@ module RedisMemo::MemoizeMethod
 
     positional_args = []
     kwargs = {}
-    named_rest = false
     depends_on_args = [ref] + args
     options = depends_on_args.extract_options!
 
+    # Keep track of the splat start index, and the number of positional args before and after the splat,
+    # so we can map which args belong to positional args and which args belong to the splat.
+    named_splat = false
+    splat_index = nil
+    num_positional_args_after_splat = 0
+    num_positional_args_before_splat = 0
+
     depends_on.parameters.each_with_index do |param, i|
-      unless param.size != 2 || param.last == :_
-        # Defined by https://github.com/ruby/ruby/blob/22b8ddfd1049c3fd1e368684c4fd03bceb041b3a/proc.c#L3048-L3059
-        case param.first
-        when :opt, :req
-          positional_args << depends_on_args[i]
-        when :rest
-          named_rest = true
-          positional_args.concat(depends_on_args[i..-1])
-        when :key, :keyreq
-          kwargs[param.last] = options[param.last]
-        when :keyrest
-          kwargs.merge!(options)
+      # Defined by https://github.com/ruby/ruby/blob/22b8ddfd1049c3fd1e368684c4fd03bceb041b3a/proc.c#L3048-L3059
+      case param.first
+      when :opt, :req
+        if splat_index
+          num_positional_args_after_splat += 1
         else
-          raise(RedisMemo::ArgumentError, "#{param.first} argument isn't supported in the dependency block")
+          num_positional_args_before_splat += 1
         end
+      when :rest
+        named_splat = is_named?(param)
+        splat_index = i
+      when :key, :keyreq
+        kwargs[param.last] = options[param.last] if is_named?(param)
+      when :keyrest
+        kwargs.merge!(options) if is_named?(param)
+      else
+        raise(RedisMemo::ArgumentError, "#{param.first} argument isn't supported in the dependency block")
       end
     end
+
+    # Determine the named positional and splat arguments after we know the # of pos. arguments before and after splat
+    after_splat_index = depends_on_args.size - num_positional_args_after_splat
+    depends_on_args.each_with_index do |arg, i|
+      # if the index is within the splat
+      if i >= num_positional_args_before_splat && i < after_splat_index
+        positional_args << arg if named_splat
+      else
+        j = i < num_positional_args_before_splat ? i : i - (after_splat_index - splat_index) - 1
+        positional_args << arg if is_named?(depends_on.parameters[j])
+      end
+    end
+
     if !kwargs.empty?
       positional_args + [kwargs]
-    elsif named_rest && !options.empty?
+    elsif named_splat && !options.empty?
         positional_args + [options]
     else
       positional_args
     end
+  end
+
+  def self.is_named?(param)
+    param.size == 2 && param.last != :_
   end
 
   def self.method_cache_keys(future_contexts)

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -153,7 +153,7 @@ module RedisMemo::MemoizeMethod
     if !kwargs.empty?
       positional_args + [kwargs]
     elsif named_splat && !options.empty?
-        positional_args + [options]
+      positional_args + [options]
     else
       positional_args
     end

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -106,22 +106,30 @@ module RedisMemo::MemoizeMethod
     mapped_args = {}
     unless depends_on.parameters.empty? or args.empty?
       depends_on_args = [ref] + args
+      j = 0
+
       depends_on.parameters.each_with_index do |param, i|
         unless param.size != 2 || param[1] == :_
-          # If it's a single splat,
-          if param[0] == :rest
-            # take the rest of the arguments if this is the last parameter
+          case param[0]
+          # If the parameter is a splat, we take the rest of the arguments if it's the last parameter. Otherwise,
+          # parameters that come after a splat can only be keyword args / hashes.
+          when :rest
             if i == depends_on.parameters.size - 1
-              mapped_args[param[1]] = depends_on_args[i..-1]
-            # find the last element that isn't a hash, and replace those elements with a single array
+              mapped_args[param[1]] = depends_on_args[j..-1]
             else
-              splat_args = depends_on_args[i..-1].select { |x| !x.is_a?(Hash) }
-              depends_on_args[i..-1] = [splat_args, *depends_on_args[(i + splat_args.size)..-1]]
-              mapped_args[param[1]] = splat_args
+              single_splat_args = depends_on_args[j..-1].select { |x| !x.is_a?(Hash) }
+              mapped_args[param[1]] = single_splat_args
+              j += single_splat_args.size
             end
+          when :key, :keyreq
+            mapped_args[param[1]] = depends_on_args[j].try(:[], param[1])
+            depends_on_args[j]&.delete(param[1])
           else
-            mapped_args[param[1]] = depends_on_args[i]
+            mapped_args[param[1]] = depends_on_args[j]
+            j += 1
           end
+        else
+          j += 1
         end
       end
     end

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -106,9 +106,19 @@ module RedisMemo::MemoizeMethod
     mapped_args = {}
     unless depends_on.parameters.empty? or args.empty?
       depends_on_args = [ref] + args.clone
-      depends_on.parameters.each_with_index do |param, i|
+      depends_on_parameters = depends_on.parameters.clone
+      # A double splat should always be the last parameter
+      if depends_on_parameters[-1][0] == :keyrest && depends_on_args[-1].is_a?(Hash)
+        mapped_args[depends_on_parameters.pop[1]] = depends_on_args.pop
+      end
+      depends_on_parameters.each_with_index do |param, i|
         unless param[1] == :_ || param[1].nil?
-          mapped_args[param[1]] = depends_on_args[i]
+          # If it's a single splat, take the rest of the arguments
+          if param[0] == :rest
+            mapped_args[param[1]] = depends_on_args[i..-1]
+          else
+            mapped_args[param[1]] = depends_on_args[i]
+          end
         end
       end
     end

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -105,7 +105,7 @@ module RedisMemo::MemoizeMethod
   def self.map_depends_on_method_args(depends_on, ref, args)
     mapped_args = {}
     unless depends_on.parameters.empty? or args.empty?
-      depends_on_args = [ref] + args.clone
+      depends_on_args = [ref] + args
       depends_on_parameters = depends_on.parameters.clone
       # A double splat should always be the last parameter
       if depends_on_parameters[-1][0] == :keyrest && depends_on_args[-1].is_a?(Hash)

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -4,7 +4,6 @@ require_relative 'future'
 require_relative 'memoizable'
 require_relative 'middleware'
 require_relative 'options'
-require 'byebug'
 
 module RedisMemo::MemoizeMethod
   def memoize_method(method_name, method_id: nil, **options, &depends_on)

--- a/lib/redis_memo/memoize_method.rb
+++ b/lib/redis_memo/memoize_method.rb
@@ -91,6 +91,18 @@ module RedisMemo::MemoizeMethod
     end
   end
 
+  # We only look at method parameters that the dependency block cares about in order to define its dependent
+  # memos, following the convention that nil or :_ means we don't care about the parameter.
+  # Example:
+  # ```
+  #    def method(param1, param2)
+  #    end
+  #
+  #    memoize_method :method do |_, _, param2|`
+  #      depends_on RedisMemo::Memoizable.new(param2: param2)
+  #    end
+  # ```
+  #  `map_depends_on_method_args(depends_on, ref, [1, 2])` returns { param2 : 2 }
   def self.map_depends_on_method_args(depends_on, ref, args)
     mapped_args = {}
     unless depends_on.parameters.empty? or args.empty?

--- a/lib/redis_memo/memoize_query/cached_select.rb
+++ b/lib/redis_memo/memoize_query/cached_select.rb
@@ -111,7 +111,7 @@ class RedisMemo::MemoizeQuery::CachedSelect
           sql.gsub(/(\$\d+)/, '?')      # $1 -> ?
              .gsub(/((, *)*\?)+/, '?')  # (?, ?, ? ...) -> (?)
         end,
-      ) do |_, sql, name, binds, **kwargs|
+      ) do |_, sql, _, binds, **|
         RedisMemo::MemoizeQuery::CachedSelect
           .current_query_bind_params
           .params

--- a/spec/memoizable/dependency_spec.rb
+++ b/spec/memoizable/dependency_spec.rb
@@ -179,11 +179,11 @@ describe RedisMemo::Memoizable::Invalidation do
 
       it 'works using a dependency block with a splat' do
         obj.class_eval do
-          memoize_method :test do |_, _, *args|; end
+          memoize_method :test do |_, _, *args, _, a|; end
         end
         RedisMemo::Cache.with_local_cache do
-          add_test_case([2, 3, {b: 1}]) { 5.times { obj.test(1, 2, 3, b: 1) } }
-          add_test_case([2, 3, 4]) { 5.times { obj.test(1, 2, 3, 4) } }
+          add_test_case([2, 3, 5]) { 5.times { obj.test(1, 2, 3, 4, 5) } }
+          add_test_case([2, 3, 5, {b: 1}]) { 5.times { obj.test(1, 2, 3, 4, 5, b: 1) } }
         end
       end
 
@@ -199,12 +199,12 @@ describe RedisMemo::Memoizable::Invalidation do
 
       it 'works using a dependency block with anonomyous splats' do
         obj.class_eval do
-          memoize_method :test do |_, a, b, *, c:, **|; end
+          memoize_method :test do |_, a, b, *, c, d:, **|; end
         end
         RedisMemo::Cache.with_local_cache do
-          add_test_case([1, 2, {c: 3}]) do
-            5.times { obj.test(1, 2, 3, c: 3) }
-            5.times { obj.test(1, 2, 3, 4, 5, 6, c: 3, d: 4) }
+          add_test_case([1, 1, 1, {d: 3}]) do
+            5.times { obj.test(1, 1, 2, 3, 1, d: 3) }
+            5.times { obj.test(1, 1, 3, 4, 5, 1, d: 3, e: 3) }
           end
         end
       end


### PR DESCRIPTION
### Summary
1. For the local dependency cache, use the class object instead of the instance as a key. The dependency block's first argument is always the instance anyway, so extracted dependencies can be shared at the class level.
2. Only look at method arguments which the dependency block cares about in order to define dependent memos, following the convention that `:_` means we don't care about the argument. This helps us locally cache extracting dependencies from an Arel query without having to further call different connection methods to get values (e.g. prepare, name).


### Testing
Added a spec for the new scenario.