### PR TITLE
[change] Drop support for depends_on ActiveRecord model

### DIFF
--- a/lib/redis_memo/memoize_query/cached_select.rb
+++ b/lib/redis_memo/memoize_query/cached_select.rb
@@ -111,15 +111,8 @@ class RedisMemo::MemoizeQuery::CachedSelect
           sql.gsub(/(\$\d+)/, '?')      # $1 -> ?
              .gsub(/((, *)*\?)+/, '?')  # (?, ?, ? ...) -> (?)
         end,
-      ) do |_, sql, name, binds, **kwargs|
-        RedisMemo::MemoizeQuery::CachedSelect
-          .current_query_bind_params
-          .params
-          .each do |model, attrs_set|
-            attrs_set.each do |attrs|
-              depends_on model, **attrs
-            end
-          end
+      ) do |_, sql, _, binds, **|
+        depends_on RedisMemo::MemoizeQuery::CachedSelect.current_query_bind_params
 
         depends_on RedisMemo::Memoizable.new(
           __redis_memo_memoize_query_memoize_query_sql__: sql,


### PR DESCRIPTION
### Summary
This marks `depends_on Model, **attrs` as a private API. Users can no longer set dependencies on some queries without calling `extract_bind_params`.

### Test Plan
- ci