### PR TITLE
[feature] Optimize invalidation for bulk_upsert

### DIFF
--- a/lib/redis_memo/options.rb
+++ b/lib/redis_memo/options.rb
@@ -72,7 +72,6 @@ class RedisMemo::Options
   end
 
   attr_accessor :async
-  attr_accessor :bulk_operations_invalidation_limit
   attr_accessor :cache_out_of_date_handler
   attr_accessor :cache_validation_sampler
   attr_accessor :compress

--- a/spec/memoize_query_spec.rb
+++ b/spec/memoize_query_spec.rb
@@ -258,6 +258,30 @@ describe RedisMemo::MemoizeQuery do
         end
       end
 
+      if Site.respond_to?(:upsert_all)
+        it 'recalculates after upsert' do
+          RedisMemo::Cache.with_local_cache do
+            site = Site.create!(a: 0)
+            expect_to_eq_with_or_without_redis do
+              Site.find(site.id)
+            end
+
+            records = 5.times.map { {a: 2} }
+            Site.upsert_all(records)
+            expect(Site.a_count(2)).to eq(7)
+
+            Site.upsert(records.last)
+            expect(Site.a_count(2)).to eq(8)
+
+            Site.upsert({a: 0})
+            # site(a: 0) is not affected by the imports
+            expect_not_to_use_redis do
+              5.times { Site.find(site.id) }
+            end
+          end
+        end
+      end
+
       it 'recalculates after import' do
         RedisMemo::Cache.with_local_cache do
           site = Site.create!(a: 0)
@@ -285,38 +309,6 @@ describe RedisMemo::MemoizeQuery do
           # site(a: 0) is not affected by the imports
           expect_not_to_use_redis do
             5.times { Site.find(site.id) }
-          end
-        end
-      end
-
-      it 'invalidates all records if there are too many records to invalidate' do
-        allow(RedisMemo::DefaultOptions).to receive(:bulk_operations_invalidation_limit).and_return(2)
-        expect(RedisMemo::MemoizeQuery).to receive(:invalidate_all).once.and_call_original
-
-        records = 3.times.map { Site.create!(a: 0) }
-        new_records = [Site.create!(a: 1), Site.create!(a: 1)]
-        new_records.each do |record|
-          record.a = 0
-          # it does not access this field for querying records to invalidate
-          expect(record).not_to receive(:not_memoized)
-        end
-
-        RedisMemo::Cache.with_local_cache do
-          records.each do |record|
-            Site.find(record.id)
-
-            # Cached locally
-            expect_not_to_use_redis do
-              Site.find(record.id)
-            end
-          end
-
-          Site.import(new_records, on_duplicate_key_update: [:a, :not_memoized])
-
-          records.each do |record|
-            expect_to_eq_with_or_without_redis do
-              Site.find(record.id)
-            end
           end
         end
       end


### PR DESCRIPTION
### Summary
This changes the upsert invalidation to use `select_by_conflict_target`. By selecting by the conflict target, we will be strictly selecting fewer records than columns_to_update, since the number of rows that satisfy the conflict target is less or equal to the number of records we're importing.

### Test Plan
- added test cases
- ci