### PR TITLE
[fix] Handle nil conflict_target_relation

### DIFF
--- a/lib/redis_memo/memoize_query/invalidation.rb
+++ b/lib/redis_memo/memoize_query/invalidation.rb
@@ -254,6 +254,8 @@ class RedisMemo::MemoizeQuery::Invalidation
   end
 
   def self.select_by_conflict_target_relation(model_class, relation)
+    return [] unless relation
+
     RedisMemo::Tracer.trace(
       'redis_memo.memoize_query.invalidation',
       "#{__method__}##{model_class.name}",

--- a/spec/memoize_query_spec.rb
+++ b/spec/memoize_query_spec.rb
@@ -306,6 +306,7 @@ describe RedisMemo::MemoizeQuery do
           expect(Site.a_count(4)).to eq(5)
 
           Site.import([])
+          Site.import([], on_duplicate_key_update: [:a])
           # site(a: 0) is not affected by the imports
           expect_not_to_use_redis do
             5.times { Site.find(site.id) }


### PR DESCRIPTION
### Summary
When importing an empty array, conflict_target_relation could be nil and could not be loaded.

### Test Plan
- added a test case
- ci