### PR TITLE
Release v0.1.1

### DIFF
--- a/redis-memo.gemspec
+++ b/redis-memo.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name          = 'redis-memo'
-  s.version       = '0.1.0'
+  s.version       = '0.1.1'
   s.date          = '2020-10-31'
   s.summary       = 'A Redis-based version-addressable caching system. Memoize pure functions, aggregated database queries, and 3rd party API calls.'
   s.authors       = ['Chan Zuckerberg Initiative']


### PR DESCRIPTION
### Bug Fix
- Handle nil conflict_target_relation (#49) . This is needed to bump the version in traject.