### PR TITLE
[feature][testing] Override default redis-memo behavior for more robust testing

### DIFF
--- a/lib/redis_memo/testing.rb
+++ b/lib/redis_memo/testing.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Redis memo can be flaky due to transient network errors (e.g. Redis connection errors), or when
+# used with async handlers. This class allows users to override the default redis-memo behavior
+# to be more robust when testing their code that uses redis-memo.
+module RedisMemo
+  class Testing
+
+    def self.__test_mode
+      @__test_mode
+    end
+
+    def self.__test_mode=(mode)
+      @__test_mode = mode
+    end
+
+    def self.enable_test_mode(&blk)
+      __set_test_mode(true, &blk)
+    end
+
+    def self.disable_test_mode(&blk)
+      __set_test_mode(false, &blk)
+    end
+
+    def self.enabled?
+      __test_mode
+    end
+
+    private
+
+    def self.__set_test_mode(mode, &blk)
+      if blk.nil?
+        __test_mode = mode
+      else
+        prev_mode = __test_mode
+        begin
+          __test_mode = mode
+          yield
+        ensure
+          __test_mode = prev_mode
+        end
+      end
+    end
+  end
+
+  module TestOverrides
+    def without_memo?
+      if RedisMemo::Testing.enabled? && !RedisMemo::Memoizable::Invalidation.class_variable_get(:@@invalidation_queue).empty?
+        return true
+      end
+      super
+    end
+  end
+  singleton_class.prepend(TestOverrides)
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,7 @@ RSpec.configure do |config|
   config.before(:each) do
     RedisMemo::Cache.redis.flushdb
     DatabaseCleaner.strategy = :truncation
+    RedisMemo::Memoizable::Invalidation.drain_invalidation_queue
   end
 
   config.after(:each) do

--- a/spec/testing_spec.rb
+++ b/spec/testing_spec.rb
@@ -1,15 +1,17 @@
 require 'redis_memo/testing'
 
 describe RedisMemo::Testing do
-  klass = Class.new do
+  let(:klass) {
+    Class.new do
 
-    def self.test; end
+      def self.test; end
 
-    class << self
-      extend RedisMemo::MemoizeMethod
-      memoize_method :test
+      class << self
+        extend RedisMemo::MemoizeMethod
+        memoize_method :test
+      end
     end
-  end
+  }
 
   def expect_no_caching
     expect(RedisMemo::Cache).to_not receive(:read_multi)

--- a/spec/testing_spec.rb
+++ b/spec/testing_spec.rb
@@ -23,7 +23,7 @@ describe RedisMemo::Testing do
     yield
   end
 
-  context 'when enabled globally' do
+  context 'when set globally' do
     RedisMemo::Testing.enable_test_mode
 
     it 'falls back to non-cached method if invalidation queue is non-empty' do
@@ -33,9 +33,17 @@ describe RedisMemo::Testing do
         klass.test
       end
     end
+
+    it 'disables test mode globally' do
+      RedisMemo::Testing.disable_test_mode
+      expect_caching do
+        RedisMemo::Memoizable::Invalidation.class_variable_get(:@@invalidation_queue) << RedisMemo::Memoizable::Invalidation::Task.new('key', 'version', nil)
+        klass.test
+      end
+    end
   end
 
-  context 'when not enabled globally' do
+  context 'when not set globally' do
     RedisMemo::Memoizable::Invalidation.class_variable_get(:@@invalidation_queue) << RedisMemo::Memoizable::Invalidation::Task.new('key', 'version', nil)
     
     it 'is only enabled for the given block' do

--- a/spec/testing_spec.rb
+++ b/spec/testing_spec.rb
@@ -1,0 +1,49 @@
+require 'redis_memo/testing'
+
+describe RedisMemo::Testing do
+  klass = Class.new do
+
+    def self.test; end
+
+    class << self
+      extend RedisMemo::MemoizeMethod
+      memoize_method :test
+    end
+  end
+
+  def expect_no_caching
+    expect(RedisMemo::Cache).to_not receive(:read_multi)
+    yield
+  end
+
+  def expect_caching
+    expect(RedisMemo::Cache).to receive(:read_multi).at_least(:once).and_call_original
+    yield
+  end
+
+  context 'when enabled globally' do
+    RedisMemo::Testing.enable_test_mode
+
+    it 'falls back to non-cached method if invalidation queue is non-empty' do
+      expect_caching { klass.test }
+      expect_no_caching do
+        RedisMemo::Memoizable::Invalidation.class_variable_get(:@@invalidation_queue) << RedisMemo::Memoizable::Invalidation::Task.new('key', 'version', nil)
+        klass.test
+      end
+    end
+  end
+
+  context 'when not enabled globally' do
+    RedisMemo::Memoizable::Invalidation.class_variable_get(:@@invalidation_queue) << RedisMemo::Memoizable::Invalidation::Task.new('key', 'version', nil)
+    
+    it 'is only enabled for the given block' do
+      expect_caching { klass.test }
+      expect_no_caching do
+        RedisMemo::Testing.enable_test_mode do
+          klass.test
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
### Summary
We've seen flaky specs for code which uses redis-memo in traject. One hypothesis is that Redis transient connection errors are causing cache invalidation to not work each time.

This PR allows overriding the default behavior of redis-memo so that invaildation is more robust. If the invalidation queue is not. empty before callilng a memoized method, fall back to `RedisMemo.without_memo`

This is loosely based on how [sidekiq](https://github.com/mperham/sidekiq/blob/f0ddebc7406fe4b78333fbc5f14488a38b9ccebc/lib/sidekiq/testing.rb) has different testing modes and overrides default behavior.

### Test Plan
Wrote some specs to test the behavior of the class.