### PR TITLE
[feature] Support Arel queries with order by

### DIFF
--- a/lib/redis_memo/memoize_query/cached_select.rb
+++ b/lib/redis_memo/memoize_query/cached_select.rb
@@ -267,9 +267,6 @@ class RedisMemo::MemoizeQuery::CachedSelect
 
       bind_params
     when Arel::Nodes::SelectStatement
-      # No OREDER BY
-      return unless node.orders.empty?
-
       node.cores.each do |core|
         # We don't support JOINs
         return unless core.source.right.empty?

--- a/spec/memoize_query_spec.rb
+++ b/spec/memoize_query_spec.rb
@@ -428,9 +428,18 @@ describe RedisMemo::MemoizeQuery do
     end
   end
 
-  it 'does not memoize ordered queries' do
-    expect_not_to_use_redis do
-      Site.order(:a).take(5)
+  context 'for ordered queries' do 
+    it 'does not memoize unbound ordered queries' do
+      expect_not_to_use_redis do
+        Site.order(:a).take(5)
+      end
+    end
+
+    it 'memoizes bounded ordered queries' do
+      record = Site.create!(a: 1)
+      expect_to_use_redis do
+        expect(Site.where(a: 1).order(:a).to_a).to eq([record])
+      end
     end
   end
 


### PR DESCRIPTION
https://app.clubhouse.io/czi-edu/story/65265/redis-memo-sql-ast-support-order-by

order by query should be supported since `node.orders` is not considered when parsing `node.cores`, and whatever in the `node.orders` should not be considered as a dependency. Made the change by removing the restriction on order_by and added test cases for bounded and unbounded order by queries.

Open to suggestion as this is my first time committing to this repo, and thanks @donaldong so much for the help!! 