### PR TITLE
[fix] Fall back to uncached flow while extracting arel dependencies if active record queries are disabled

### DIFF
--- a/lib/redis_memo/memoizable/dependency.rb
+++ b/lib/redis_memo/memoizable/dependency.rb
@@ -50,9 +50,12 @@ class RedisMemo::Memoizable::Dependency
   private
 
   def self.extract_from_relation(relation)
+    connection = ActiveRecord::Base.connection
+    unless connection.respond_to?(:dependency_of)
+      raise RedisMemo::WithoutMemoization, 'Caching active record queries is currently disabled on RedisMemo'
+    end
     # Extract the dependent memos of an Arel without calling exec_query to actually execute the query
     RedisMemo::MemoizeQuery::CachedSelect.with_new_query_context do
-      connection = ActiveRecord::Base.connection
       query, binds, _ = connection.send(:to_sql_and_binds, relation.arel)
       RedisMemo::MemoizeQuery::CachedSelect.current_query = relation.arel
       is_query_cached = RedisMemo::MemoizeQuery::CachedSelect.extract_bind_params(query)

--- a/spec/memoizable/dependency_spec.rb
+++ b/spec/memoizable/dependency_spec.rb
@@ -384,6 +384,7 @@ describe RedisMemo::Memoizable::Invalidation do
     end
 
     it 'falls back to the uncached method when queries are disabled for caching', :disable_cached_select do
+      allow(ActiveRecord::Base.connection).to receive(:respond_to?).and_call_original
       allow(ActiveRecord::Base.connection).to receive(:respond_to?).with(:dependency_of).and_return(false)
       record = SpecModel.create!(a: 1)
       record.calc_count = 0

--- a/spec/memoizable/dependency_spec.rb
+++ b/spec/memoizable/dependency_spec.rb
@@ -383,6 +383,15 @@ describe RedisMemo::Memoizable::Invalidation do
       }.to change { record.calc_count }.by(10)
     end
 
+    it 'falls back to the uncached method when queries are disabled for caching', :disable_cached_select do
+      allow(ActiveRecord::Base.connection).to receive(:respond_to?).with(:dependency_of).and_return(false)
+      record = SpecModel.create!(a: 1)
+      record.calc_count = 0
+      expect {
+        5.times { record.calc }
+      }.to change { record.calc_count }.by(5)
+    end
+
     it 'supports conditional memoization by raising a WithoutMemoization error' do
       record = SpecModel.create!(a: 1)
       record.calc_count = 0


### PR DESCRIPTION
### Summary
If the kill switch is on to disable all cached select queries on redis-memo, then memoize_method is never called for `connection.exec_query`, and therefore :dependency_of is never dynamically defined. This falls back to the uncached method in case `:dependency_of` is not defined.

### Test Plan