### PR TITLE
[feature] Add max connection attempts to RedisMemo middleware

### DIFF
--- a/lib/redis_memo.rb
+++ b/lib/redis_memo.rb
@@ -110,7 +110,8 @@ module RedisMemo
   end
 
   # Fall back to RedisMemo.without_memo if the maximum connection attempts has been reached for a single request
-  def self.incr_max_connection_attempts
+  private
+  def self.incr_connection_attempts # :nodoc:
     return if Thread.current[THREAD_KEY_MAX_CONNECTION_ATTEMPTS].nil? || Thread.current[THREAD_KEY_CONNECTION_ATTEMPTS_COUNT].nil?
 
     Thread.current[THREAD_KEY_CONNECTION_ATTEMPTS_COUNT] += 1

--- a/lib/redis_memo.rb
+++ b/lib/redis_memo.rb
@@ -19,6 +19,8 @@ module RedisMemo
 
   # @todo Move thread keys to +RedisMemo::ThreadKey+
   THREAD_KEY_WITHOUT_MEMO = :__redis_memo_without_memo__
+  THREAD_KEY_CONNECTION_ATTEMPTS_COUNT = :__redis_memo_connection_attempts_count__
+  THREAD_KEY_MAX_CONNECTION_ATTEMPTS = :__redis_memo_max_connection_attempts__
 
   # Configure global-level default options. Those options will be used unless
   # some options specified at +memoize_method+ callsite level. See
@@ -92,6 +94,29 @@ module RedisMemo
     yield
   ensure
     Thread.current[THREAD_KEY_WITHOUT_MEMO] = prev_value
+  end
+
+  def self.with_max_connection_attempts(max_attempts)
+    prev_value = Thread.current[THREAD_KEY_WITHOUT_MEMO]
+    if max_attempts
+      Thread.current[THREAD_KEY_CONNECTION_ATTEMPTS_COUNT] = 0
+      Thread.current[THREAD_KEY_MAX_CONNECTION_ATTEMPTS] = max_attempts
+    end
+    yield
+  ensure
+    Thread.current[THREAD_KEY_WITHOUT_MEMO] = prev_value
+    Thread.current[THREAD_KEY_CONNECTION_ATTEMPTS_COUNT] = nil
+    Thread.current[THREAD_KEY_MAX_CONNECTION_ATTEMPTS] = nil
+  end
+
+  # Fall back to RedisMemo.without_memo if the maximum connection attempts has been reached for a single request
+  def self.incr_max_connection_attempts
+    return if Thread.current[THREAD_KEY_MAX_CONNECTION_ATTEMPTS].nil? || Thread.current[THREAD_KEY_CONNECTION_ATTEMPTS_COUNT].nil?
+
+    Thread.current[THREAD_KEY_CONNECTION_ATTEMPTS_COUNT] += 1
+    if Thread.current[THREAD_KEY_CONNECTION_ATTEMPTS_COUNT] >= Thread.current[THREAD_KEY_MAX_CONNECTION_ATTEMPTS]
+      Thread.current[THREAD_KEY_WITHOUT_MEMO] = true
+    end
   end
 
   # @todo Move errors to a separate file errors.rb

--- a/lib/redis_memo/cache.rb
+++ b/lib/redis_memo/cache.rb
@@ -17,12 +17,11 @@ class RedisMemo::Cache < ActiveSupport::Cache::RedisCacheStore
     RedisMemo::DefaultOptions.redis_error_handler&.call(exception, method)
     RedisMemo::DefaultOptions.logger&.warn(exception.full_message)
 
+    RedisMemo.incr_max_connection_attempts if exception.is_a?(Redis::BaseConnectionError)
+
     if Thread.current[THREAD_KEY_RAISE_ERROR]
       raise RedisMemo::Cache::Rescuable
     else
-      if exception.is_a?(Redis::BaseConnectionError)
-        RedisMemo.incr_max_connection_attempts
-      end
       returning
     end
   end

--- a/lib/redis_memo/cache.rb
+++ b/lib/redis_memo/cache.rb
@@ -17,7 +17,7 @@ class RedisMemo::Cache < ActiveSupport::Cache::RedisCacheStore
     RedisMemo::DefaultOptions.redis_error_handler&.call(exception, method)
     RedisMemo::DefaultOptions.logger&.warn(exception.full_message)
 
-    RedisMemo.incr_max_connection_attempts if exception.is_a?(Redis::BaseConnectionError)
+    RedisMemo.incr_connection_attempts if exception.is_a?(Redis::BaseConnectionError)
 
     if Thread.current[THREAD_KEY_RAISE_ERROR]
       raise RedisMemo::Cache::Rescuable

--- a/lib/redis_memo/cache.rb
+++ b/lib/redis_memo/cache.rb
@@ -20,6 +20,9 @@ class RedisMemo::Cache < ActiveSupport::Cache::RedisCacheStore
     if Thread.current[THREAD_KEY_RAISE_ERROR]
       raise RedisMemo::Cache::Rescuable
     else
+      if exception.is_a?(Redis::BaseConnectionError)
+        RedisMemo.incr_max_connection_attempts
+      end
       returning
     end
   end

--- a/lib/redis_memo/middleware.rb
+++ b/lib/redis_memo/middleware.rb
@@ -9,7 +9,9 @@ class RedisMemo::Middleware
     result = nil
 
     RedisMemo::Cache.with_local_cache do
-      result = @app.call(env)
+      RedisMemo.with_max_connection_attempts(ENV['REDIS_MEMO_MAX_ATTEMPTS_PER_REQUEST']&.to_i) do
+        result = @app.call(env)
+      end
     end
     RedisMemo::Memoizable::Invalidation.drain_invalidation_queue
 


### PR DESCRIPTION
### Summary
- If there's an issue with the Redis server and a request makes multiple calls to the RedisMemo cache, it'll just keep timing out and failing to connect. This can cause a request which makes multiple cache calls to be really slow.

- To mitigate this issue, keep track of the connection attempts and max connection attempts in a thread local variable. If we reach the max connection attempts, fall back to `RedisMemo.without_memo` for the rest of the request.

### Testing
- Wrote specs for new feature
- Still testing a bit manually, but I ran traject locally and pointed to this branch, and can confirm that when redis raises connection errors, it only attempts to connect n times.