### PR TITLE
[feature] Add redis memo env variable for global kill switch

### DIFF
--- a/lib/redis_memo.rb
+++ b/lib/redis_memo.rb
@@ -80,7 +80,7 @@ module RedisMemo
   #
   # @return [Boolean]
   def self.without_memo?
-    Thread.current[THREAD_KEY_WITHOUT_MEMO] == true
+    ENV["REDIS_MEMO_DISABLE_ALL"] == 'true' || Thread.current[THREAD_KEY_WITHOUT_MEMO] == true
   end
 
   # Configure the wrapped code in the block to skip memoization.

--- a/lib/redis_memo/memoize_query.rb
+++ b/lib/redis_memo/memoize_query.rb
@@ -13,6 +13,7 @@ if defined?(ActiveRecord)
     # after each record save
     def memoize_table_column(*raw_columns, editable: true)
       RedisMemo::MemoizeQuery.using_active_record!(self)
+      return if ENV["REDIS_MEMO_DISABLE_ALL"] == 'true'
       return if ENV["REDIS_MEMO_DISABLE_#{self.table_name.upcase}"] == 'true'
 
       columns = raw_columns.map(&:to_sym).sort


### PR DESCRIPTION
### Summary
Add a global kill switch for redis-memo. This should turn off all calls to the redis cache, as well as installing the auto-invalidation classes for memoized table columns on ActiveRecord.

### Testing
Tested manually on traject that this works.