### PR TITLE
Log errors and call error handler on invalidation

### DIFF
--- a/lib/redis_memo/memoizable/invalidation.rb
+++ b/lib/redis_memo/memoizable/invalidation.rb
@@ -127,7 +127,10 @@ module RedisMemo::Memoizable::Invalidation
       begin
         bump_version(task)
       rescue SignalException, Redis::BaseConnectionError,
-             ::ConnectionPool::TimeoutError
+        ::ConnectionPool::TimeoutError => e
+
+        RedisMemo::DefaultOptions.redis_error_handler&.call(e, __method__)
+        RedisMemo::DefaultOptions.logger&.warn(e.full_message)
         retry_queue << task
       end
     end


### PR DESCRIPTION
### Summary
I think it'd be helpful to use the error handler/log errors on invalidation. We still haven't figured out why rspecs are sometimes flaky with redis-memo - while we see cache out of date errors, we don't see any invalidation errors.