### PR TITLE
[feature] enable caching on queries with NOT

### DIFF
--- a/lib/redis_memo/memoize_query/cached_select.rb
+++ b/lib/redis_memo/memoize_query/cached_select.rb
@@ -324,7 +324,7 @@ class RedisMemo::MemoizeQuery::CachedSelect
 
         return unless bind_params
       end
-      
+
       bind_params
     when Arel::Nodes::Union, Arel::Nodes::Or
       [node.left, node.right].each do |child|
@@ -336,7 +336,7 @@ class RedisMemo::MemoizeQuery::CachedSelect
       end
 
       bind_params
-    
+
     when Arel::Nodes::NotEqual
       return bind_params
     else

--- a/lib/redis_memo/memoize_query/cached_select.rb
+++ b/lib/redis_memo/memoize_query/cached_select.rb
@@ -338,6 +338,8 @@ class RedisMemo::MemoizeQuery::CachedSelect
       bind_params
 
     when Arel::Nodes::NotEqual
+      # We don't cache based on NOT queries (where.not) because it is unbound
+      # but we memoize queries with NOT and other bound queries, so we return the original bind_params
       return bind_params
     else
       # Not yet supported

--- a/lib/redis_memo/memoize_query/cached_select.rb
+++ b/lib/redis_memo/memoize_query/cached_select.rb
@@ -324,7 +324,7 @@ class RedisMemo::MemoizeQuery::CachedSelect
 
         return unless bind_params
       end
-
+      
       bind_params
     when Arel::Nodes::Union, Arel::Nodes::Or
       [node.left, node.right].each do |child|
@@ -336,6 +336,9 @@ class RedisMemo::MemoizeQuery::CachedSelect
       end
 
       bind_params
+    
+    when Arel::Nodes::NotEqual
+      return bind_params
     else
       # Not yet supported
       return

--- a/spec/memoize_query_spec.rb
+++ b/spec/memoize_query_spec.rb
@@ -443,11 +443,53 @@ describe RedisMemo::MemoizeQuery do
     end
   end
 
-  it 'does not memoize queries with NOT' do
-    expect_not_to_use_redis do
-      Site.where(id: Site.where.not(a: 1)).to_a
+  context 'when the queries have NOT' do 
+    let!(:record) { Site.create!(a: 1, b: 1) }
+    let!(:relation_with_only_not) { Site.where.not(a: 2) }
+    let!(:relation_with_not_and_other) { Site.where.not(a: 2).where(b: 1) }
+
+    it 'does not memoize queries with only NOT' do
+      expect_not_to_use_redis do
+        expect(relation_with_only_not.to_a).to eq([record])
+      end
     end
-  end
+
+    it 'memoizes queries with both NOT and other bound conditions' do
+      expect_to_use_redis do
+        expect(relation_with_not_and_other.to_a).to eq([record])
+      end
+    end
+
+    it 'it updates the affected query result' do
+      record.update(a: 2)
+
+      expect_to_use_redis do
+        expect(relation_with_not_and_other.reload.to_a).to eq([])
+      end
+    end
+
+    it 'only invalidates the affected query result sets' do
+      RedisMemo::Cache.with_local_cache do 
+        # WHERE a != 2 and b = 1
+        expect_to_use_redis do
+          expect(relation_with_not_and_other.to_a).to eq([record])
+        end
+        
+        Site.create!(b: 2)
+
+        # The new created record does not affect WHERE a != 2 and b = 1
+        expect_not_to_use_redis do
+          expect(relation_with_not_and_other.reload.to_a).to eq([record])
+        end
+
+        # when an affected update happens, it updates the affected results
+        record.update!(a: 2)
+        expect_to_use_redis do
+          expect(relation_with_not_and_other.reload.to_a).to eq([])
+        end
+      end
+    end
+  end  
 
   it 'does not memoize queries with non-memoized columns' do
     expect_not_to_use_redis do

--- a/spec/memoize_query_spec.rb
+++ b/spec/memoize_query_spec.rb
@@ -445,12 +445,22 @@ describe RedisMemo::MemoizeQuery do
 
   context 'when the queries have NOT' do 
     let!(:record) { Site.create!(a: 1, b: 1) }
-    let!(:relation_with_only_not) { Site.where.not(a: 2) }
+    let!(:relation1_with_only_not) { Site.where.not(a: 2) }
+    let!(:relation2_with_only_not) { Site.where.not(a: 2, b: 1) }
+    let!(:relation3_with_only_not) { Site.where.not(a: 2).where.not(b: 1) }
     let!(:relation_with_not_and_other) { Site.where.not(a: 2).where(b: 1) }
 
     it 'does not memoize queries with only NOT' do
       expect_not_to_use_redis do
-        expect(relation_with_only_not.to_a).to eq([record])
+        expect(relation1_with_only_not.to_a).to eq([record])
+      end
+
+      expect_not_to_use_redis do
+        expect(relation2_with_only_not.to_a).to eq([record])
+      end
+
+      expect_not_to_use_redis do
+        expect(relation3_with_only_not.to_a).to eq([])
       end
     end
 


### PR DESCRIPTION
### Summary 
This PR enables queries with that has both NOT and other bound queries. 

Previously we decided to not to cache any queries with NOT, however, queries with both NOT and other bound queries can be cached. E.g
```
Site.where(a: 1).where.not(b: 1) can be cached based on a as dependency 
Site.where.not(b: 1) should not be cached
```

My current approach is to return `bind_params` when we parse a `notequal` statement, so that 
- for queries with only NOT, we return an empty object 
- for queries with NOT and other bound conditions, it will involve those conditions and cache

### Test plan
rspec 