### PR TITLE
[feature] support more queries with range (>=, <= etc)

### DIFF
--- a/lib/redis_memo/memoize_query/cached_select.rb
+++ b/lib/redis_memo/memoize_query/cached_select.rb
@@ -337,11 +337,6 @@ class RedisMemo::MemoizeQuery::CachedSelect
       end
 
       bind_params
-
-    when Arel::Nodes::NotEqual
-      # We don't cache based on NOT queries (where.not) because it is unbound
-      # but we memoize queries with NOT and other bound queries, so we return the original bind_params
-      return bind_params
     else
       # Not yet supported
       return
@@ -379,7 +374,6 @@ class RedisMemo::MemoizeQuery::CachedSelect
   class NodeHasComparators
     def self.===(node)
       case node
-      # TODO(Christina): remove the single Arel::Nodes::NotEqual block in line 141 after the NodeHasComparators changes are merged
       when Arel::Nodes::LessThan, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThan, Arel::Nodes::GreaterThanOrEqual, Arel::Nodes::NotEqual
         true
       else

--- a/lib/redis_memo/memoize_query/cached_select.rb
+++ b/lib/redis_memo/memoize_query/cached_select.rb
@@ -313,7 +313,6 @@ class RedisMemo::MemoizeQuery::CachedSelect
       bind_params
     when Arel::Nodes::Grouping
       # Inline SQL
-      return bind_params if is_comparison_expr(node.expr)
       extract_bind_params_recurse(node.expr)
     when Arel::Nodes::LessThan, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThan, Arel::Nodes::GreaterThanOrEqual, Arel::Nodes::NotEqual
       return bind_params 
@@ -341,12 +340,6 @@ class RedisMemo::MemoizeQuery::CachedSelect
       # Not yet supported
       return
     end
-  end
-
-  # Whether the expression of the node has the compare operators
-  def self.is_comparison_expr(expr)
-    return false if !expr.is_a?(Arel::Nodes::SqlLiteral)
-    %w[> >= < <= !=].any?{ |comparator| expr.to_s.include?(comparator) }
   end
 
   def self.extract_binding_relation(table_node)

--- a/lib/redis_memo/memoize_query/cached_select.rb
+++ b/lib/redis_memo/memoize_query/cached_select.rb
@@ -315,7 +315,7 @@ class RedisMemo::MemoizeQuery::CachedSelect
       # Inline SQL
       return bind_params if is_comparison_expr(node.expr)
       extract_bind_params_recurse(node.expr)
-    when NodeHasComparators
+    when Arel::Nodes::LessThan, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThan, Arel::Nodes::GreaterThanOrEqual, Arel::Nodes::NotEqual
       return bind_params 
     when Arel::Nodes::And
       node.children.each do |child|
@@ -346,8 +346,7 @@ class RedisMemo::MemoizeQuery::CachedSelect
   # Whether the expression of the node has the compare operators
   def self.is_comparison_expr(expr)
     return false if !expr.is_a?(Arel::Nodes::SqlLiteral)
-    compare_operators = ['>', '>=', '<', '<=', '!=']
-    compare_operators.any?{ |comparator| expr.to_s.include?(comparator) }
+    %w[> >= < <= !=].any?{ |comparator| expr.to_s.include?(comparator) }
   end
 
   def self.extract_binding_relation(table_node)
@@ -367,17 +366,6 @@ class RedisMemo::MemoizeQuery::CachedSelect
         else
           false
         end
-      end
-    end
-  end
-
-  class NodeHasComparators
-    def self.===(node)
-      case node
-      when Arel::Nodes::LessThan, Arel::Nodes::LessThanOrEqual, Arel::Nodes::GreaterThan, Arel::Nodes::GreaterThanOrEqual, Arel::Nodes::NotEqual
-        true
-      else
-        false
       end
     end
   end

--- a/spec/memoize_query_spec.rb
+++ b/spec/memoize_query_spec.rb
@@ -612,4 +612,231 @@ describe RedisMemo::MemoizeQuery do
       expect_to_eq_with_or_without_redis { relation_with_and_or_clause.reload }
     end
   end
+
+  context 'when the queries have compare operators (unbound)' do
+    RSpec.shared_examples 'does not memoize queries with only compare operators' do
+      it 'does not memoize queries with only compare operators' do 
+        # The relation1_with_only_comparator, relation2_with_only_comparator and relation3_with_only_comparator are all relations with 
+        # only compare operators which will not be cached, e.g. SELECT * FROM SITE WHERE a > 1
+        expect_not_to_use_redis do
+          expect(relation1_with_only_comparator.to_a).to eq(result)
+        end
+  
+        expect_not_to_use_redis do
+          expect(relation2_with_only_comparator.to_a).to eq(result)
+        end
+
+        expect_not_to_use_redis do
+          expect(relation3_with_only_comparator.to_a).to eq(result)
+        end
+      end
+    end
+
+    # The relation1_with_comparator_and_other and relation2_with_comparator_and_other both have unbound and bound conditions,
+    # so they can be cached partially, e.g. SELECT * FROM SITE WHERE a > 1 and b = 2
+    RSpec.shared_examples 'memoizes queries with both comparator and other bound conditions' do
+      it 'memoizes queries with both comparator and other bound conditions' do
+        expect_to_use_redis do
+          expect(relation1_with_comparator_and_other.to_a).to eq(result)
+        end
+  
+        expect_to_use_redis do
+          expect(relation2_with_comparator_and_other.to_a).to eq(result)
+        end
+      end
+    end
+
+    RSpec.shared_examples 'when update happens to the records' do
+      it 'it updates the affected query result' do
+        update
+        expect_to_use_redis do
+          expect(relation1_with_comparator_and_other.reload.to_a).to eq(result)
+        end
+  
+        expect_to_use_redis do
+          expect(relation2_with_comparator_and_other.reload.to_a).to eq(result)
+        end
+      end
+    end
+
+    RSpec.shared_examples 'with local cache' do
+      it 'only invalidates the affected query result sets' do
+        RedisMemo::Cache.with_local_cache do 
+          expect_to_use_redis do
+            expect(relation1_with_comparator_and_other.to_a).to eq(unaffected_result)
+          end
+  
+          expect_to_use_redis do
+            expect(relation2_with_comparator_and_other.to_a).to eq(unaffected_result)
+          end
+  
+          unaffected_creation
+  
+          # Does not affect with the creation because it is not dependent
+          expect_not_to_use_redis do
+            expect(relation1_with_comparator_and_other.reload.to_a).to eq(unaffected_result)
+          end
+  
+          expect_not_to_use_redis do
+            expect(relation2_with_comparator_and_other.reload.to_a).to eq(unaffected_result)
+          end
+  
+          update
+  
+          # Will affect with the update
+          expect_to_use_redis do
+            expect(relation1_with_comparator_and_other.reload.to_a).to eq(affected_result)
+          end
+  
+          expect_to_use_redis do
+            expect(relation2_with_comparator_and_other.reload.to_a).to eq(affected_result)
+          end
+        end
+      end
+    end
+  end
+
+  context 'when the queries have greater than operators (unbound)' do
+    let!(:record) { Site.create!(a: 2, b: 2) }
+    
+    # The following two relations are both SELECT * FROM Site where a > 1
+    let!(:relation1_with_only_comparator) { Site.where('a > ?', 1) }
+    let!(:relation2_with_only_comparator) { Site.where(a: 2..Float::INFINITY) }
+    let!(:relation3_with_only_comparator) { Site.where('a > ? AND b = ?', 1, 2) }
+
+    # The following two relations are both SELECT * FROM Site where a > 1 AND b = 2
+    let!(:relation1_with_comparator_and_other) { Site.where('a > ?', 1).where(b: 2) }
+    let!(:relation2_with_comparator_and_other) { Site.where(a: 2..Float::INFINITY).where(b: 2) }
+
+    # Deliberately use let below to let it be lazy-evaluated
+    # An update which will affect the results of the relation_with_comparator_and_other above
+    let(:update) { record.update(a: 1) }
+    # A creation which will not affect the results of the relation_with_comparator_and_other above
+    let(:unaffected_creation) { Site.create(b: 1) }
+
+    it_behaves_like 'does not memoize queries with only compare operators' do 
+      let!(:result) { [record] }
+    end
+
+    it_behaves_like 'memoizes queries with both comparator and other bound conditions' do 
+      let!(:result) { [record] }
+    end
+
+    it_behaves_like 'when update happens to the records' do 
+      let!(:result) { [] }
+    end
+
+    it_behaves_like 'with local cache' do 
+      let!(:unaffected_result) { [record] }
+      let!(:affected_result) { [] }
+    end
+  end
+
+  context 'when the queries have greater than or equal operators (unbound)' do
+    let!(:record) { Site.create!(a: 2, b: 2) }
+
+    # The following two relations are both SELECT * FROM Site where a >= 2
+    let!(:relation1_with_only_comparator) { Site.where('a >= ?', 2) }
+    let!(:relation2_with_only_comparator) { Site.where(a: 2..Float::INFINITY) }
+    let!(:relation3_with_only_comparator) { Site.where('a >= ? AND b = ?', 2, 2) }
+
+    # The following two relations are both SELECT * FROM Site where a >= 2 AND b = 2
+    let!(:relation1_with_comparator_and_other) { Site.where('a >= ?', 2).where(b: 2) }
+    let!(:relation2_with_comparator_and_other) { Site.where(a: 2..Float::INFINITY).where(b: 2) }
+
+    # Deliberately use let below to let it be lazy-evaluated
+    # An update which will affect the results of the relation_with_comparator_and_other above
+    let(:update) { record.update(a: 1) }
+    # A creation which will not affect the results of the relation_with_comparator_and_other above
+    let(:unaffected_creation) { Site.create(b: 1) }
+
+    it_behaves_like 'does not memoize queries with only compare operators' do 
+      let!(:result) { [record] }
+    end
+
+    it_behaves_like 'memoizes queries with both comparator and other bound conditions' do 
+      let!(:result) { [record] }
+    end
+
+    it_behaves_like 'when update happens to the records' do 
+      let!(:result) { [] }
+    end
+
+    it_behaves_like 'with local cache' do 
+      let!(:unaffected_result) { [record] }
+      let!(:affected_result) { [] }
+    end
+  end
+
+  context 'when the queries have less than operators (unbound)' do
+    let!(:record) { Site.create!(a: 1, b: 2) }
+
+    # The following two relations are both SELECT * FROM Site where a < 2
+    let!(:relation1_with_only_comparator) { Site.where('a < ?', 2) }
+    let!(:relation2_with_only_comparator) { Site.where(a: -Float::INFINITY..1) }
+    let!(:relation3_with_only_comparator) { Site.where('a < ? AND b = ?', 2, 2) }
+
+    # The following two relations are both SELECT * FROM Site where a < 2 AND b = 2
+    let!(:relation1_with_comparator_and_other) { Site.where('a < ?', 2).where(b: 2) }
+    let!(:relation2_with_comparator_and_other) { Site.where(a: -Float::INFINITY..1).where(b: 2) }
+
+    # Deliberately use let below to let it be lazy-evaluated
+    # An update which will affect the results of the relation_with_comparator_and_other above
+    let(:update) { record.update(a: 2) }
+    # A creation which will not affect the results of the relation_with_comparator_and_other above
+    let(:unaffected_creation) { Site.create(b: 1) }
+
+    it_behaves_like 'does not memoize queries with only compare operators' do 
+      let!(:result) { [record] }
+    end
+
+    it_behaves_like 'memoizes queries with both comparator and other bound conditions' do 
+      let!(:result) { [record] }
+    end
+
+    it_behaves_like 'when update happens to the records' do 
+      let!(:result) { [] }
+    end
+
+    it_behaves_like 'with local cache' do 
+      let!(:unaffected_result) { [record] }
+      let!(:affected_result) { [] }
+    end
+  end
+
+  context 'when the queries have less than or equal operators (unbound)' do
+    let!(:record) { Site.create!(a: 1, b: 2) }
+
+    # The following two relations are both SELECT * FROM Site where a <= 1
+    let!(:relation1_with_only_comparator) { Site.where('a <= ?', 1) }
+    let!(:relation2_with_only_comparator) { Site.where(a: -Float::INFINITY..1) }
+    let!(:relation3_with_only_comparator) { Site.where('a <= ? AND b = ?', 1, 2) }
+
+    # The following two relations are both SELECT * FROM Site where a <= 1 AND b = 2
+    let!(:relation1_with_comparator_and_other) { Site.where('a <= ?', 1).where(b: 2) }
+    let!(:relation2_with_comparator_and_other) { Site.where(a: -Float::INFINITY..1).where(b: 2) }
+
+    # Deliberately use let below to let it be lazy-evaluated
+    # An update which will affect the results of the relation_with_comparator_and_other above
+    let(:update) { record.update(a: 2) }
+    # A creation which will not affect the results of the relation_with_comparator_and_other above
+    let(:unaffected_creation) { Site.create(b: 1) }
+
+    it_behaves_like 'does not memoize queries with only compare operators' do 
+      let!(:result) { [record] }
+    end
+
+    it_behaves_like 'memoizes queries with both comparator and other bound conditions' do 
+      let!(:result) { [record] }
+    end
+
+    it_behaves_like 'when update happens to the records' do 
+      let!(:result) { [] }
+    end
+
+    it_behaves_like 'with local cache' do 
+      let!(:unaffected_result) { [record] }
+      let!(:affected_result) { [] }
+    end
+  end
 end


### PR DESCRIPTION
### Summary 
This PR is to support the queries that have range in it. such as '>=', '<=', etc., and also combine the `NotEqual` query we had in #62 since they can all be merged into the `NodeHasComparator` condition in this PR.

Regarding the rspec, I created several shared examples so we can test multiple similar behaviors. 

### Details 
Previously we decided to not to cache any queries with these comparison operators, however, queries with both comparison operators and other bound queries can be cached. E.g
```
Site.where(a: 1).where('b > ?' 1) can be cached based on a as dependency 
Site.where('b > ?' 1) should not be cached
```

Also, as according to [here](https://piechowski.io/post/how-to-use-greater-than-less-than-active-record/), there are two forms of queries with comparator: 
1. Site.where(a: 1).where('b > ?' 1) -- this will be analyzed as `Arel::Nodes::Grouping` when we parse the children of the wheres, thus, we look at `node.expr` of it. `node.expr` is usually a `Arel::Nodes::SqlLiteral` in this case
2. Site.where(a: 1).where(b: 2..Float::INFINITY) -- this will be analyzed as `Arel::Nodes::LessThan` when we parse the children of the wheres, thus, we categorize `Arel::Nodes::LessThan` and also other node class as `NodeHasComparators`

My current approach is to return `bind_params` when we parse these statements 
- for queries with the only a comparator, we return an empty object 
- for queries with the comparator and other bound conditions, it will involve those conditions and cache

### Test plan
- rspec for >=, >, <=, <

### TODO: 
remove the duplicate Arel::Nodes::NotEqual block in #62 since they are brought in this PR