### PR TITLE
[bug fix] Rescue ConnectionPool::TimeoutError

### DIFF
--- a/lib/redis_memo/cache.rb
+++ b/lib/redis_memo/cache.rb
@@ -57,6 +57,8 @@ class RedisMemo::Cache < ActiveSupport::Cache::RedisCacheStore
     Thread.current[THREAD_KEY_LOCAL_DEPENDENCY_CACHE]
   end
 
+  # See https://github.com/rails/rails/blob/fe76a95b0d252a2d7c25e69498b720c96b243ea2/activesupport/lib/active_support/cache/redis_cache_store.rb#L477
+  # We overwrite this private method so we can also rescue ConnectionPool::TimeoutErrors
   def failsafe(method, returning: nil)
     yield
   rescue ::Redis::BaseError, ::ConnectionPool::TimeoutError => e

--- a/lib/redis_memo/cache.rb
+++ b/lib/redis_memo/cache.rb
@@ -57,6 +57,14 @@ class RedisMemo::Cache < ActiveSupport::Cache::RedisCacheStore
     Thread.current[THREAD_KEY_LOCAL_DEPENDENCY_CACHE]
   end
 
+  def failsafe(method, returning: nil)
+    yield
+  rescue ::Redis::BaseError, ::ConnectionPool::TimeoutError => e
+    handle_exception exception: e, method: method, returning: returning
+    returning
+  end
+  private :failsafe
+
   class << self
     def with_local_cache(&blk)
       Thread.current[THREAD_KEY_LOCAL_CACHE] = {}


### PR DESCRIPTION
### Summary
redis_cache_store only rescues `Redis::BaseErrors`. We should also rescue `ConnectionPool::TimeoutErrors` thrown from the connection_pool gem, since these are transient and shouldn't fail the request if the cache read/write fails.

Overwrite the private method failsafe defined in [redis_cache_store](https://github.com/rails/rails/blob/fe76a95b0d252a2d7c25e69498b720c96b243ea2/activesupport/lib/active_support/cache/redis_cache_store.rb#L477) to also catch ConnectionPool::TimeoutErrors.

### Test Plan
- Wrote additional specs
- I think the build currently on main is failing, unrelated to this change