### PR TITLE
[feature] Use railtie to load middleware

### DIFF
--- a/lib/redis_memo.rb
+++ b/lib/redis_memo.rb
@@ -7,7 +7,8 @@ require 'securerandom'
 
 module RedisMemo
   require 'redis_memo/memoize_method'
-  require 'redis_memo/memoize_query'
+  require 'redis_memo/memoize_query' if defined?(ActiveRecord)
+  require 'redis_memo/railtie' if defined?(Rails) && defined?(Rails::Railtie)
 
   # A process-level +RedisMemo::Options+ instance that stores the global
   # options. This object can be modified by +RedisMemo.configure+.

--- a/lib/redis_memo/memoize_query.rb
+++ b/lib/redis_memo/memoize_query.rb
@@ -1,152 +1,150 @@
 # frozen_string_literal: true
 require_relative 'memoize_method'
 
-if defined?(ActiveRecord)
-  # Hook into ActiveRecord to cache SQL queries and perform auto cache
-  # invalidation
-  module RedisMemo::MemoizeQuery
-    require_relative 'memoize_query/cached_select'
-    require_relative 'memoize_query/invalidation'
-    require_relative 'memoize_query/model_callback'
+# Hook into ActiveRecord to cache SQL queries and perform auto cache
+# invalidation
+module RedisMemo::MemoizeQuery
+  require_relative 'memoize_query/cached_select'
+  require_relative 'memoize_query/invalidation'
+  require_relative 'memoize_query/model_callback'
 
-    # Only editable columns will be used to create memos that are invalidatable
-    # after each record save
-    def memoize_table_column(*raw_columns, editable: true)
-      RedisMemo::MemoizeQuery.using_active_record!(self)
-      return if ENV["REDIS_MEMO_DISABLE_ALL"] == 'true'
-      return if ENV["REDIS_MEMO_DISABLE_#{self.table_name.upcase}"] == 'true'
+  # Only editable columns will be used to create memos that are invalidatable
+  # after each record save
+  def memoize_table_column(*raw_columns, editable: true)
+    RedisMemo::MemoizeQuery.using_active_record!(self)
+    return if ENV["REDIS_MEMO_DISABLE_ALL"] == 'true'
+    return if ENV["REDIS_MEMO_DISABLE_#{self.table_name.upcase}"] == 'true'
 
-      columns = raw_columns.map(&:to_sym).sort
+    columns = raw_columns.map(&:to_sym).sort
 
-      RedisMemo::MemoizeQuery.memoized_columns(self, editable_only: true) << columns if editable
-      RedisMemo::MemoizeQuery.memoized_columns(self, editable_only: false) << columns
+    RedisMemo::MemoizeQuery.memoized_columns(self, editable_only: true) << columns if editable
+    RedisMemo::MemoizeQuery.memoized_columns(self, editable_only: false) << columns
 
-      RedisMemo::MemoizeQuery::ModelCallback.install(self)
-      RedisMemo::MemoizeQuery::Invalidation.install(self)
+    RedisMemo::MemoizeQuery::ModelCallback.install(self)
+    RedisMemo::MemoizeQuery::Invalidation.install(self)
 
-      if ENV['REDIS_MEMO_DISABLE_CACHED_SELECT'] != 'true'
-        RedisMemo::MemoizeQuery::CachedSelect.install(ActiveRecord::Base.connection)
-      end
-
-      # The code below might fail due to missing DB/table errors
-      columns.each do |column|
-        unless self.columns_hash.include?(column.to_s)
-          raise(
-            RedisMemo::ArgumentError,
-            "'#{self.name}' does not contain column '#{column}'",
-          )
-        end
-      end
-
-      unless ENV["REDIS_MEMO_DISABLE_QUERY_#{self.table_name.upcase}"] == 'true'
-        RedisMemo::MemoizeQuery::CachedSelect.enabled_models[self.table_name] = self
-      end
-    rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
-      # no-opts: models with memoize_table_column decleared might be loaded in
-      # rake tasks that are used to create databases
+    if ENV['REDIS_MEMO_DISABLE_CACHED_SELECT'] != 'true'
+      RedisMemo::MemoizeQuery::CachedSelect.install(ActiveRecord::Base.connection)
     end
 
-    def self.using_active_record!(model_class)
-      unless using_active_record?(model_class)
-        raise RedisMemo::ArgumentError, "'#{model_class.name}' does not use ActiveRecord"
-      end
-    end
-
-    def self.using_active_record?(model_class)
-      model_class.respond_to?(:<) && model_class < ActiveRecord::Base
-    end
-
-    @@memoized_columns = Hash.new { |h, k| h[k] = [Set.new, Set.new] }
-
-    def self.memoized_columns(model_or_table, editable_only: false)
-      table = model_or_table.is_a?(Class) ? model_or_table.table_name : model_or_table
-      @@memoized_columns[table.to_sym][editable_only ? 1 : 0]
-    end
-
-    # extra_props are considered as AND conditions on the model class
-    def self.create_memo(model_class, **extra_props)
-      using_active_record!(model_class)
-
-      keys = extra_props.keys.sort
-      if !keys.empty? && !memoized_columns(model_class).include?(keys)
+    # The code below might fail due to missing DB/table errors
+    columns.each do |column|
+      unless self.columns_hash.include?(column.to_s)
         raise(
           RedisMemo::ArgumentError,
-          "'#{model_class.name}' has not memoized columns: #{keys}",
+          "'#{self.name}' does not contain column '#{column}'",
         )
       end
+    end
 
-      extra_props.each do |key, value|
-        # The data type is ensured by the database, thus we don't need to cast
-        # types here for better performance
-        column_name = key.to_s
-        extra_props[key] =
-          if model_class.defined_enums.include?(column_name)
-            enum_mapping = model_class.defined_enums[column_name]
-            # Assume a value is a converted enum if it does not exist in the
-            # enum mapping
-            (enum_mapping[value.to_s] || value).to_s
-          else
-            value.to_s
-          end
-      end
+    unless ENV["REDIS_MEMO_DISABLE_QUERY_#{self.table_name.upcase}"] == 'true'
+      RedisMemo::MemoizeQuery::CachedSelect.enabled_models[self.table_name] = self
+    end
+  rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
+    # no-opts: models with memoize_table_column decleared might be loaded in
+    # rake tasks that are used to create databases
+  end
 
-      RedisMemo::Memoizable.new(
-        __redis_memo_memoize_query_table_name__: model_class.table_name,
-        **extra_props,
+  def self.using_active_record!(model_class)
+    unless using_active_record?(model_class)
+      raise RedisMemo::ArgumentError, "'#{model_class.name}' does not use ActiveRecord"
+    end
+  end
+
+  def self.using_active_record?(model_class)
+    model_class.respond_to?(:<) && model_class < ActiveRecord::Base
+  end
+
+  @@memoized_columns = Hash.new { |h, k| h[k] = [Set.new, Set.new] }
+
+  def self.memoized_columns(model_or_table, editable_only: false)
+    table = model_or_table.is_a?(Class) ? model_or_table.table_name : model_or_table
+    @@memoized_columns[table.to_sym][editable_only ? 1 : 0]
+  end
+
+  # extra_props are considered as AND conditions on the model class
+  def self.create_memo(model_class, **extra_props)
+    using_active_record!(model_class)
+
+    keys = extra_props.keys.sort
+    if !keys.empty? && !memoized_columns(model_class).include?(keys)
+      raise(
+        RedisMemo::ArgumentError,
+        "'#{model_class.name}' has not memoized columns: #{keys}",
       )
     end
 
-    def self.invalidate_all(model_class)
-      RedisMemo::Tracer.trace(
-        'redis_memo.memoizable.invalidate_all',
-        model_class.name,
-      ) do
-        RedisMemo::Memoizable.invalidate([model_class.redis_memo_class_memoizable])
+    extra_props.each do |key, value|
+      # The data type is ensured by the database, thus we don't need to cast
+      # types here for better performance
+      column_name = key.to_s
+      extra_props[key] =
+        if model_class.defined_enums.include?(column_name)
+          enum_mapping = model_class.defined_enums[column_name]
+          # Assume a value is a converted enum if it does not exist in the
+          # enum mapping
+          (enum_mapping[value.to_s] || value).to_s
+        else
+          value.to_s
+        end
+    end
+
+    RedisMemo::Memoizable.new(
+      __redis_memo_memoize_query_table_name__: model_class.table_name,
+      **extra_props,
+    )
+  end
+
+  def self.invalidate_all(model_class)
+    RedisMemo::Tracer.trace(
+      'redis_memo.memoizable.invalidate_all',
+      model_class.name,
+    ) do
+      RedisMemo::Memoizable.invalidate([model_class.redis_memo_class_memoizable])
+    end
+  end
+
+  def self.invalidate(*records)
+    RedisMemo::Memoizable.invalidate(
+      records.map { |record| to_memos(record) }.flatten,
+    )
+  end
+
+  def self.to_memos(record)
+    # Invalidate memos with current values
+    memos_to_invalidate = memoized_columns(record.class).map do |columns|
+      props = {}
+      columns.each do |column|
+        props[column] = record.send(column)
       end
+
+      create_memo(record.class, **props)
     end
 
-    def self.invalidate(*records)
-      RedisMemo::Memoizable.invalidate(
-        records.map { |record| to_memos(record) }.flatten,
-      )
-    end
+    # Create memos with previous values if
+    #  - there are saved changes
+    #  - this is not creating a new record
+    if !record.saved_changes.empty? && !record.saved_changes.include?(record.class.primary_key)
+      previous_values = {}
+      record.saved_changes.each do |column, (previous_value, _)|
+        previous_values[column.to_sym] = previous_value
+      end
 
-    def self.to_memos(record)
-      # Invalidate memos with current values
-      memos_to_invalidate = memoized_columns(record.class).map do |columns|
-        props = {}
+      memoized_columns(record.class, editable_only: true).each do |columns|
+        props = previous_values.slice(*columns)
+        next if props.empty?
+
+        # Fill the column values that have not changed
         columns.each do |column|
+          next if props.include?(column)
+
           props[column] = record.send(column)
         end
 
-        create_memo(record.class, **props)
+        memos_to_invalidate << create_memo(record.class, **props)
       end
-
-      # Create memos with previous values if
-      #  - there are saved changes
-      #  - this is not creating a new record
-      if !record.saved_changes.empty? && !record.saved_changes.include?(record.class.primary_key)
-        previous_values = {}
-        record.saved_changes.each do |column, (previous_value, _)|
-          previous_values[column.to_sym] = previous_value
-        end
-
-        memoized_columns(record.class, editable_only: true).each do |columns|
-          props = previous_values.slice(*columns)
-          next if props.empty?
-
-          # Fill the column values that have not changed
-          columns.each do |column|
-            next if props.include?(column)
-
-            props[column] = record.send(column)
-          end
-
-          memos_to_invalidate << create_memo(record.class, **props)
-        end
-      end
-
-      memos_to_invalidate
     end
+
+    memos_to_invalidate
   end
 end

--- a/lib/redis_memo/railtie.rb
+++ b/lib/redis_memo/railtie.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class RedisMemo::Railtie < Rails::Railtie
+  initializer 'request_store.insert_middleware' do |app|
+    if ActionDispatch.const_defined? :RequestId
+      app.config.middleware.insert_after ActionDispatch::RequestId, RedisMemo::Middleware
+    else
+      app.config.middleware.insert_after Rack::MethodOverride, RedisMemo::Middleware
+    end
+  end
+end

--- a/redis-memo.gemspec
+++ b/redis-memo.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'codecov'
   s.add_development_dependency 'database_cleaner-active_record'
   s.add_development_dependency 'pg'
+  s.add_development_dependency 'railties', '>= 5.2'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.2'
   s.add_development_dependency 'simplecov'

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -1,0 +1,12 @@
+describe RedisMemo::Railtie do
+  class TestApplication < Rails::Application; end
+
+  TestApplication.configure do
+    config.eager_load = false
+  end
+
+  it 'inserts middleware' do
+    Rails.application.initialize!
+    expect(Rails.application.middleware.include?(RedisMemo::Middleware)).to eq(true)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'database_cleaner/active_record'
+require 'rails'
 require 'simplecov'
 
 SimpleCov.start


### PR DESCRIPTION
This uses railties to load RedisMemo::Middleware. The implementation is identical to https://github.com/steveklabnik/request_store/blob/master/lib/request_store/railtie.rb.

If a project has both RedisMemo and RequestStore configured, RedisMemo and RequestStore middleware will be next to each other. Their relative ordering does not matter much.

### Test Plan
- added a test case to describe this behavior
- ci