### PR TITLE
[cleanup] Move redis-memo specific environment variables into DefaultOptions

### DIFF
--- a/lib/redis_memo.rb
+++ b/lib/redis_memo.rb
@@ -66,7 +66,7 @@ module RedisMemo
   #
   # @return [Boolean]
   def self.without_memo?
-    ENV["REDIS_MEMO_DISABLE_ALL"] == 'true' || ThreadLocalVar.without_memo == true
+    RedisMemo::DefaultOptions.disable_all || ThreadLocalVar.without_memo == true
   end
 
   # Configure the wrapped code in the block to skip memoization.

--- a/lib/redis_memo/memoize_query.rb
+++ b/lib/redis_memo/memoize_query.rb
@@ -23,7 +23,7 @@ module RedisMemo::MemoizeQuery
     RedisMemo::MemoizeQuery::ModelCallback.install(self)
     RedisMemo::MemoizeQuery::Invalidation.install(self)
 
-    if ENV['REDIS_MEMO_DISABLE_CACHED_SELECT'] != 'true'
+    unless RedisMemo::DefaultOptions.disable_cached_select
       RedisMemo::MemoizeQuery::CachedSelect.install(ActiveRecord::Base.connection)
     end
 

--- a/lib/redis_memo/memoize_query.rb
+++ b/lib/redis_memo/memoize_query.rb
@@ -13,7 +13,7 @@ module RedisMemo::MemoizeQuery
   def memoize_table_column(*raw_columns, editable: true)
     RedisMemo::MemoizeQuery.using_active_record!(self)
     return if RedisMemo::DefaultOptions.disable_all
-    return if RedisMemo::DefaultOptions.disabled_models.include?(self)
+    return if RedisMemo::DefaultOptions.model_disabled_for_caching?(self)
 
     columns = raw_columns.map(&:to_sym).sort
 
@@ -37,7 +37,7 @@ module RedisMemo::MemoizeQuery
       end
     end
 
-    unless RedisMemo::DefaultOptions.disabled_models.include?(self)
+    unless RedisMemo::DefaultOptions.model_disabled_for_caching?(self)
       RedisMemo::MemoizeQuery::CachedSelect.enabled_models[self.table_name] = self
     end
   rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid

--- a/lib/redis_memo/memoize_query.rb
+++ b/lib/redis_memo/memoize_query.rb
@@ -13,7 +13,7 @@ module RedisMemo::MemoizeQuery
   def memoize_table_column(*raw_columns, editable: true)
     RedisMemo::MemoizeQuery.using_active_record!(self)
     return if RedisMemo::DefaultOptions.disable_all
-    return if ENV["REDIS_MEMO_DISABLE_#{self.table_name.upcase}"] == 'true'
+    return if RedisMemo::DefaultOptions.disabled_models.include?(self)
 
     columns = raw_columns.map(&:to_sym).sort
 
@@ -37,7 +37,7 @@ module RedisMemo::MemoizeQuery
       end
     end
 
-    unless ENV["REDIS_MEMO_DISABLE_QUERY_#{self.table_name.upcase}"] == 'true'
+    unless RedisMemo::DefaultOptions.disabled_models.include?(self)
       RedisMemo::MemoizeQuery::CachedSelect.enabled_models[self.table_name] = self
     end
   rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid

--- a/lib/redis_memo/memoize_query.rb
+++ b/lib/redis_memo/memoize_query.rb
@@ -12,7 +12,7 @@ module RedisMemo::MemoizeQuery
   # after each record save
   def memoize_table_column(*raw_columns, editable: true)
     RedisMemo::MemoizeQuery.using_active_record!(self)
-    return if ENV["REDIS_MEMO_DISABLE_ALL"] == 'true'
+    return if RedisMemo::DefaultOptions.disable_all
     return if ENV["REDIS_MEMO_DISABLE_#{self.table_name.upcase}"] == 'true'
 
     columns = raw_columns.map(&:to_sym).sort

--- a/lib/redis_memo/middleware.rb
+++ b/lib/redis_memo/middleware.rb
@@ -9,7 +9,7 @@ class RedisMemo::Middleware
     result = nil
 
     RedisMemo::Cache.with_local_cache do
-      RedisMemo.with_max_connection_attempts(ENV['REDIS_MEMO_MAX_ATTEMPTS_PER_REQUEST']&.to_i) do
+      RedisMemo.with_max_connection_attempts(RedisMemo::Options.max_connection_attempts) do
         result = @app.call(env)
       end
     end

--- a/lib/redis_memo/options.rb
+++ b/lib/redis_memo/options.rb
@@ -9,7 +9,9 @@ class RedisMemo::Options
     redis_error_handler: nil,
     tracer: nil,
     global_cache_key_version: nil,
-    expires_in: nil
+    expires_in: nil,
+    disable_all: false,
+    disabled_tables: Set.new
   )
     @compress = compress.nil? ? true : compress
     @compress_threshold = compress_threshold || 1.kilobyte
@@ -20,6 +22,7 @@ class RedisMemo::Options
     @logger = logger
     @global_cache_key_version = global_cache_key_version
     @expires_in = expires_in
+    @disable_all = disable_all
   end
 
   def redis
@@ -79,6 +82,7 @@ class RedisMemo::Options
   attr_accessor :connection_pool
   attr_accessor :expires_in
   attr_accessor :redis_error_handler
+  attr_accessor :disable_all
 
   attr_writer :global_cache_key_version
   attr_writer :tracer

--- a/lib/redis_memo/options.rb
+++ b/lib/redis_memo/options.rb
@@ -10,6 +10,7 @@ class RedisMemo::Options
     tracer: nil,
     global_cache_key_version: nil,
     expires_in: nil,
+    max_connection_attempts: nil,
     disable_all: false,
     disable_cached_select: false,
     disabled_models: Set.new
@@ -23,6 +24,7 @@ class RedisMemo::Options
     @logger = logger
     @global_cache_key_version = global_cache_key_version
     @expires_in = expires_in
+    @max_connection_attempts = max_connection_attempts
     @disable_all = disable_all
     @disable_cached_select = disable_cached_select
     @disabled_models = disabled_models
@@ -88,6 +90,7 @@ class RedisMemo::Options
   attr_accessor :compress_threshold
   attr_accessor :connection_pool
   attr_accessor :expires_in
+  attr_accessor :max_connection_attempts
   attr_accessor :redis_error_handler
   attr_accessor :disable_all
   attr_accessor :disable_cached_select

--- a/lib/redis_memo/options.rb
+++ b/lib/redis_memo/options.rb
@@ -11,6 +11,7 @@ class RedisMemo::Options
     global_cache_key_version: nil,
     expires_in: nil,
     disable_all: false,
+    disable_cached_select: false,
     disabled_models: Set.new
   )
     @compress = compress.nil? ? true : compress
@@ -23,6 +24,7 @@ class RedisMemo::Options
     @global_cache_key_version = global_cache_key_version
     @expires_in = expires_in
     @disable_all = disable_all
+    @disable_cached_select = disable_cached_select
     @disabled_models = disabled_models
   end
 
@@ -88,6 +90,7 @@ class RedisMemo::Options
   attr_accessor :expires_in
   attr_accessor :redis_error_handler
   attr_accessor :disable_all
+  attr_accessor :disable_cached_select
   attr_accessor :disabled_models
 
   attr_writer :global_cache_key_version

--- a/lib/redis_memo/options.rb
+++ b/lib/redis_memo/options.rb
@@ -11,7 +11,7 @@ class RedisMemo::Options
     global_cache_key_version: nil,
     expires_in: nil,
     disable_all: false,
-    disabled_tables: Set.new
+    disabled_models: Set.new
   )
     @compress = compress.nil? ? true : compress
     @compress_threshold = compress_threshold || 1.kilobyte
@@ -23,6 +23,7 @@ class RedisMemo::Options
     @global_cache_key_version = global_cache_key_version
     @expires_in = expires_in
     @disable_all = disable_all
+    @disabled_models = disabled_models
   end
 
   def redis
@@ -74,6 +75,10 @@ class RedisMemo::Options
     end
   end
 
+  def disable_model(model)
+    @disabled_models << model
+  end
+
   attr_accessor :async
   attr_accessor :cache_out_of_date_handler
   attr_accessor :cache_validation_sampler
@@ -83,6 +88,7 @@ class RedisMemo::Options
   attr_accessor :expires_in
   attr_accessor :redis_error_handler
   attr_accessor :disable_all
+  attr_accessor :disabled_models
 
   attr_writer :global_cache_key_version
   attr_writer :tracer

--- a/lib/redis_memo/options.rb
+++ b/lib/redis_memo/options.rb
@@ -24,9 +24,9 @@ class RedisMemo::Options
     @logger = logger
     @global_cache_key_version = global_cache_key_version
     @expires_in = expires_in
-    @max_connection_attempts = max_connection_attempts
-    @disable_all = disable_all
-    @disable_cached_select = disable_cached_select
+    @max_connection_attempts = ENV['REDIS_MEMO_MAX_ATTEMPTS_PER_REQUEST']&.to_i || max_connection_attempts
+    @disable_all = ENV['REDIS_MEMO_DISABLE_ALL'] == 'true' || disable_all
+    @disable_cached_select = ENV['REDIS_MEMO_DISABLE_CACHED_SELECT'] == 'true' || disable_cached_select
     @disabled_models = disabled_models
   end
 
@@ -83,6 +83,10 @@ class RedisMemo::Options
     @disabled_models << model
   end
 
+  def model_disabled_for_caching?(model)
+    ENV["REDIS_MEMO_DISABLE_#{model.table_name.upcase}"] == 'true' || @disabled_models.include?(model)
+  end
+
   attr_accessor :async
   attr_accessor :cache_out_of_date_handler
   attr_accessor :cache_validation_sampler
@@ -94,7 +98,6 @@ class RedisMemo::Options
   attr_accessor :redis_error_handler
   attr_accessor :disable_all
   attr_accessor :disable_cached_select
-  attr_accessor :disabled_models
 
   attr_writer :global_cache_key_version
   attr_writer :tracer

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -1,5 +1,4 @@
 # typed: false
-
 describe RedisMemo::Options do
   context 'cache validation' do
     it 'validates the cache result' do
@@ -102,27 +101,10 @@ describe RedisMemo::Options do
 
         expect_no_caching do
           # Check that query caching is disabled on the model
-          5.times { TestModel.find(test_model.id) }
+          TestModel.find(test_model.id)
 
           # Check that invalidation model callbacks are disabled on update and destroy
           expect(RedisMemo::MemoizeQuery).not_to receive(:invalidate)
-          test_model.update!(a: 1)
-          test_model.destroy!
-        end
-      end
-
-      it 'disables query caching if disable cached select flag is set' do
-        RedisMemo::DefaultOptions.disable_cached_select = true
-        TestModel.memoize_table_column :id, editable: false
-
-        test_model = TestModel.create!
-
-        expect_no_caching do
-          # Check that query caching is disabled
-          5.times { TestModel.find(test_model.id) }
-
-          # Check that invalidation model callbacks still are installed on the model
-          expect(RedisMemo::MemoizeQuery).to receive(:invalidate).twice
           test_model.update!(a: 1)
           test_model.destroy!
         end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -4,7 +4,7 @@ describe RedisMemo::Options do
 
   # Reset options to default values after each test
   after(:each) do
-    RedisMemo::DefaultOptions = RedisMemo::Options.new
+    Kernel::silence_warnings { RedisMemo::DefaultOptions = RedisMemo::Options.new }
   end
 
   it 'validates the cache result' do
@@ -60,5 +60,70 @@ describe RedisMemo::Options do
     expect {
       5.times { obj.calc }
     }.to change { obj.count }.by(5)
+  end
+
+  context 'query caching' do
+
+    before(:all) do
+      ActiveRecord::Base.connection.execute 'drop table if exists test_models'
+      ActiveRecord::Base.connection.create_table :test_models do |t|
+        t.integer 'a', default: 0
+      end
+    end
+
+    after(:all) do
+      ActiveRecord::Base.connection.execute 'drop table if exists test_models'
+    end
+
+    # Set and unset the TestModel constant to reload the model definition
+    let(:test_model_klass) { Class.new(ActiveRecord::Base) { extend RedisMemo::MemoizeQuery } }
+
+    before(:each) do
+      Object.const_set("TestModel", test_model_klass)
+    end
+
+    after(:each) do
+      Object.send(:remove_const, "TestModel")
+    end
+
+    def expect_no_caching
+      expect(RedisMemo::Cache).to_not receive(:read_multi)
+      yield
+    end
+
+    it 'disables query caching on tables that are disabled' do
+      # Reload the model and call memoize_table_column after options are set
+      RedisMemo::DefaultOptions.disable_model(TestModel)
+      TestModel.memoize_table_column :id, editable: false
+
+      test_model = TestModel.create!
+
+      expect_no_caching do
+        # Check that query caching is disabled on the model
+        5.times { TestModel.find(test_model.id) }
+
+        # Check that invalidation model callbacks are disabled on update and destroy
+        expect(RedisMemo::MemoizeQuery).not_to receive(:invalidate)
+        test_model.update!(a: 1)
+        test_model.destroy!
+      end
+    end
+
+    it 'disables query caching if disable cached select flag is set' do
+      RedisMemo::DefaultOptions.disable_cached_select = true
+      TestModel.memoize_table_column :id, editable: false
+
+      test_model = TestModel.create!
+
+      expect_no_caching do
+        # Check that query caching is disabled
+        5.times { TestModel.find(test_model.id) }
+
+        # Check that invalidation model callbacks still are installed on the model
+        expect(RedisMemo::MemoizeQuery).to receive(:invalidate).twice
+        test_model.update!(a: 1)
+        test_model.destroy!
+      end
+    end
   end
 end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -40,8 +40,8 @@ describe RedisMemo::Options do
 
   context 'disable caching options' do
     # Reset options to default values after each test
-    after(:each) do
-      Kernel::silence_warnings { RedisMemo::DefaultOptions = RedisMemo::Options.new }
+    before(:each) do
+      stub_const("RedisMemo::DefaultOptions", RedisMemo::Options.new)
     end
 
     def expect_no_caching

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -1,41 +1,64 @@
 # typed: false
 
 describe RedisMemo::Options do
-  context 'cache validation' do
-    it 'validates the cache result' do
-      allow(RedisMemo::DefaultOptions).to receive(:cache_validation_sampler) do
-        proc { true }
-      end
 
-      count = 0
+  # Reset options to default values after each test
+  after(:each) do
+    RedisMemo::DefaultOptions = RedisMemo::Options.new
+  end
 
-      allow(RedisMemo::DefaultOptions).to receive(:cache_out_of_date_handler) do
-        proc { count += 1 }
-      end
-
-      klass = Class.new do
-        extend RedisMemo::MemoizeMethod
-        attr_accessor :count
-
-        def calc
-          @count += 1
-        end
-
-        memoize_method :calc
-      end
-
-      obj = klass.new
-      obj.count = 0
-
-      # cache miss
-      expect {
-        obj.calc
-      }.to change { count }.by(0)
-
-      # cache hit
-      expect {
-        obj.calc
-      }.to change { count }.by(1)
+  it 'validates the cache result' do
+    allow(RedisMemo::DefaultOptions).to receive(:cache_validation_sampler) do
+      proc { true }
     end
+
+    count = 0
+
+    allow(RedisMemo::DefaultOptions).to receive(:cache_out_of_date_handler) do
+      proc { count += 1 }
+    end
+
+    klass = Class.new do
+      extend RedisMemo::MemoizeMethod
+      attr_accessor :count
+
+      def calc
+        @count += 1
+      end
+
+      memoize_method :calc
+    end
+
+    obj = klass.new
+    obj.count = 0
+
+    # cache miss
+    expect {
+      obj.calc
+    }.to change { count }.by(0)
+
+    # cache hit
+    expect {
+      obj.calc
+    }.to change { count }.by(1)
+  end
+
+  it 'disables caching when the disable option is set' do
+    klass = Class.new do
+      extend RedisMemo::MemoizeMethod
+      attr_accessor :count
+
+      def calc
+        @count += 1
+      end
+    end
+
+    RedisMemo::DefaultOptions.disable_all = true
+    obj = klass.new
+    obj.count = 0
+
+    expect {
+      5.times { obj.calc }
+    }.to change { obj.count }.by(5)
   end
 end


### PR DESCRIPTION
### Summary
Merge redis-memo specific env vars into the DefaultOptions class. See comment in https://github.com/chanzuckerberg/redis-memo/pull/58#discussion_r594725937

This feels like somewhat of a breaking change; when we merge this into Traject, we need to make sure to set the option values accordingly with the correct types.

### Testing
- Added specs for options to `disable_all`, and `disable_table`.
- I didn't add a test for the option `disable_cached_select`; this option installs the cached_select logic onto the connection class directly. I couldn't find a good way to force reload the connection class definition, or undo the redis-memo changes on this class, without breaking other stuff.