### PR TITLE
[feature] Move lua to a separate file, run evalsha after script is already loaded

### DIFF
--- a/lib/redis_memo/connection_pool.rb
+++ b/lib/redis_memo/connection_pool.rb
@@ -12,7 +12,7 @@ class RedisMemo::ConnectionPool
   end
 
   # Avoid method_missing when possible for better performance
-  %i[get mget mapped_mget set eval].each do |method_name|
+  %i[get mget mapped_mget set eval evalsha run_script].each do |method_name|
     define_method method_name do |*args, &blk|
       @connection_pool.with do |redis|
         redis.__send__(method_name, *args, &blk)

--- a/lib/redis_memo/memoizable/bump_version.lua
+++ b/lib/redis_memo/memoizable/bump_version.lua
@@ -1,0 +1,34 @@
+--[[
+Script to bump the version of a memoizable's cache key.
+
+RedisMemo can be used safely within transactions because it implements multi
+version concurrency control (MVCC).
+
+Before bumping dependency versions, RedisMemo will save its current version
+prior to the update. While bumping the version on Redis, RedisMemo would check
+if the current version still matches the expectation (in a Lua script to ensure atomicity).
+If not, we would use a different version that has not been used before, thus
+we have automatically invalidated the records that are being updated by overlapping
+transactions.
+--   KEYS = cache_key
+--   ARGV = [expected_prev_version desired_new_version version_on_mismatch ttl]
+--]]
+local key = KEYS[1]
+local expected_prev_version,
+      desired_new_version,
+      version_on_mismatch,
+      ttl = unpack(ARGV)
+
+local actual_prev_version = redis.call('get', key)
+local new_version = version_on_mismatch
+local px = {}
+
+if (not actual_prev_version and expected_prev_version == '') or expected_prev_version == actual_prev_version then
+  new_version = desired_new_version
+end
+
+if ttl ~= '' then
+  px = {'px', ttl}
+end
+
+return redis.call('set', key, new_version, unpack(px))

--- a/lib/redis_memo/memoizable/bump_version.lua
+++ b/lib/redis_memo/memoizable/bump_version.lua
@@ -10,6 +10,11 @@ if the current version still matches the expectation (in a Lua script to ensure 
 If not, we would use a different version that has not been used before, thus
 we have automatically invalidated the records that are being updated by overlapping
 transactions.
+
+Note: When Redis memory is full, bumping versions only works on Redis versions 6.x.
+Prior versions of Redis have a bug in Lua where an OOM error is thrown instead of
+eviction when Redis memory is full https://github.com/redis/redis/issues/6565
+
 --   KEYS = cache_key
 --   ARGV = [expected_prev_version desired_new_version version_on_mismatch ttl]
 --]]

--- a/lib/redis_memo/memoizable/invalidation.rb
+++ b/lib/redis_memo/memoizable/invalidation.rb
@@ -61,7 +61,7 @@ module RedisMemo::Memoizable::Invalidation
   end
 
   LUA_BUMP_VERSION = File.read(
-    File.join(File.dirname(__FILE__), "bump_version.lua"),
+    File.join(File.dirname(__FILE__), 'bump_version.lua'),
   )
   private_constant :LUA_BUMP_VERSION
 

--- a/lib/redis_memo/memoizable/invalidation.rb
+++ b/lib/redis_memo/memoizable/invalidation.rb
@@ -137,7 +137,7 @@ module RedisMemo::Memoizable::Invalidation
           keys: [task.key],
           argv: [task.previous_version, task.version, RedisMemo::Util.uuid, ttl],
         )
-        @@bump_version_sha = Digest::SHA1.hexdigest(LUA_BUMP_VERSION) unless @@bump_version_sha
+        @@bump_version_sha ||= Digest::SHA1.hexdigest(LUA_BUMP_VERSION)
         RedisMemo::Tracer.set_tag(enqueue_to_finish: task.duration)
       end
     end

--- a/lib/redis_memo/redis.rb
+++ b/lib/redis_memo/redis.rb
@@ -39,12 +39,12 @@ class RedisMemo::Redis < Redis::Distributed
     begin
       script_sha = @@script_shas[script_content]
       return evalsha(script_sha, *args) if script_sha
-    rescue Redis::CommandError => e
-      if e.message != 'NOSCRIPT No matching script. Please use EVAL.'
-        raise e
+    rescue Redis::CommandError => error
+      if error.message != 'NOSCRIPT No matching script. Please use EVAL.'
+        raise error
       end
     end
-    res = eval(script_content, *args)
+    res = eval(script_content, *args) # rubocop: disable Security/Eval
     script_sha = Digest::SHA1.hexdigest(script_content)
     @@script_shas[script_content] = script_sha
     res

--- a/lib/redis_memo/redis.rb
+++ b/lib/redis_memo/redis.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'digest'
 require 'redis'
 require 'redis/distributed'
 
@@ -34,20 +33,15 @@ class RedisMemo::Redis < Redis::Distributed
     super([], ring: hash_ring)
   end
 
-  @@script_shas = {}
-  def run_script(script_content, *args)
+  def run_script(script_content, script_sha, *args)
     begin
-      script_sha = @@script_shas[script_content]
       return evalsha(script_sha, *args) if script_sha
     rescue Redis::CommandError => error
       if error.message != 'NOSCRIPT No matching script. Please use EVAL.'
         raise error
       end
     end
-    res = eval(script_content, *args) # rubocop: disable Security/Eval
-    script_sha = Digest::SHA1.hexdigest(script_content)
-    @@script_shas[script_content] = script_sha
-    res
+    eval(script_content, *args) # rubocop: disable Security/Eval
   end
 
   class WithReplicas < ::Redis

--- a/spec/after_commit_spec.rb
+++ b/spec/after_commit_spec.rb
@@ -50,7 +50,7 @@ describe RedisMemo::AfterCommit do
       method.call(*args)
     end
 
-    allow(RedisMemo::Cache.redis).to receive(:eval).and_wrap_original do |method, *args|
+    allow(RedisMemo::Cache.redis).to receive(:run_script).and_wrap_original do |method, *args|
       redis_stats[:invalidation_count] += 1
       method.call(*args)
     end

--- a/spec/memoizable/invalidation_spec.rb
+++ b/spec/memoizable/invalidation_spec.rb
@@ -40,7 +40,7 @@ describe RedisMemo::Memoizable::Invalidation do
         @retry_count = 0
       end
 
-      def eval(*)
+      def run_script(*)
         return unless @retry_count < 3
 
         @retry_count += 1
@@ -74,7 +74,7 @@ describe RedisMemo::Memoizable::Invalidation do
     klass = Class.new do
       attr_accessor :done
 
-      def eval(*)
+      def run_script(*)
         sleep(1) until @done
       end
 

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -64,24 +64,34 @@ describe RedisMemo::Redis do
     expect(client.mapped_mget('a').is_a?(Hash)).to be(true)
   end
 
-  it 'calls evalsha after a script is already loaded' do
-    client = RedisMemo::Redis.new
-    client.script(:flush)
-    script = <<~LUA
-      redis.call('set', KEYS[1], ARGV[1])
-    LUA
+  context 'run_script' do
+    let(:lua_script) { "redis.call('set', KEYS[1], ARGV[1])" }
+    let(:script_sha) { Digest::SHA1.hexdigest(lua_script) }
+    let(:client) { RedisMemo::Redis.new }
 
-    # When the script sha isn't loaded on Redis, it should fall back to calling eval
-    script_sha = Digest::SHA1.hexdigest(script)
-    expect(client).to receive(:evalsha).once.and_call_original
-    expect(client).to receive(:eval).once.and_call_original
-    client.run_script(script, script_sha, keys: ['cache_key'], argv: ['cache_value'])
+    before(:each) do
+      client.script(:flush)
+    end
 
-    # Subsequent calls should use evalsha
-    5.times do
-      expect(client).to receive(:evalsha).and_call_original
-      expect(client).to_not receive(:eval)
-      client.run_script(script, script_sha, keys: ['cache_key'], argv: ['cache_value'])
+    it 'calls evalsha after a script is already loaded' do
+      # When the script sha isn't loaded on Redis, it should fall back to calling eval
+      expect(client).to receive(:evalsha).once.and_call_original
+      expect(client).to receive(:eval).once.and_call_original
+      client.run_script(lua_script, script_sha, keys: ['cache_key'], argv: ['cache_value'])
+
+      # Subsequent calls should use evalsha
+      5.times do
+        expect(client).to receive(:evalsha).and_call_original
+        expect(client).to_not receive(:eval)
+        client.run_script(lua_script, script_sha, keys: ['cache_key'], argv: ['cache_value'])
+      end
+    end
+
+    it 'only rescues NOSCRIPT errors from redis' do
+      allow(client).to receive(:evalsha).and_raise(Redis::CommandError)
+      expect {
+        client.run_script(lua_script, script_sha)
+      }.to raise_error(Redis::CommandError)
     end
   end
 end

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -1,6 +1,5 @@
 # typed: false
 describe RedisMemo::Redis do
-
   before(:each) do
     stub_const('FakeClient', Class.new do
       attr_reader :id
@@ -76,13 +75,13 @@ describe RedisMemo::Redis do
     script_sha = Digest::SHA1.hexdigest(script)
     expect(client).to receive(:evalsha).once.and_call_original
     expect(client).to receive(:eval).once.and_call_original
-    client.run_script(script, script_sha, keys: ['cache_key'], argv: ["cache_value"])
+    client.run_script(script, script_sha, keys: ['cache_key'], argv: ['cache_value'])
 
     # Subsequent calls should use evalsha
     5.times do
       expect(client).to receive(:evalsha).and_call_original
       expect(client).to_not receive(:eval)
-      client.run_script(script, script_sha, keys: ['cache_key'], argv: ["cache_value"])
+      client.run_script(script, script_sha, keys: ['cache_key'], argv: ['cache_value'])
     end
   end
 end

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -74,7 +74,7 @@ describe RedisMemo::Redis do
     expect(client).to receive(:eval).once.and_call_original
     expect(client).to receive(:evalsha).exactly(4).times
     5.times do
-      client.run_script(script, keys: ["cache_key"], argv: ["cache_value"])
+      client.run_script(script, keys: ['cache_key'], argv: ['cache_value'])
     end
   end
 end


### PR DESCRIPTION
### Summary
- Move Lua code to a separate fille and run evalsha after a script is already loaded instead of eval

### Testing
Wrote additional specs to confirm behavior