### PR TITLE
[doc] Check in an example config

### DIFF
--- a/docs/examples/config.rb
+++ b/docs/examples/config.rb
@@ -1,0 +1,102 @@
+# config/initializers/redis_memo.rb
+RedisMemo.configure do |config|
+  # Passed along to the Rails
+  # {RedisCacheStore}[https://api.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html],
+  # sets the TTL on cache entries in Redis.
+  config.expires_in = 3.hours
+
+  # A global cache key version prepended to each cached entry. For example, the
+  # commit hash of the current version deployed to your application.
+  config.global_cache_key_version = ENV['HEROKU_SLUG_COMMIT']
+
+  config.redis_error_handler = proc do |error, operation, extra|
+    ErrorReporter.notify(error, tags: { operation: operation }, extra: extra)
+  end
+
+  # Object used to log RedisMemo operations.
+  config.logger { Rails.logger }
+
+  # Sets the tracer object. Allows the tracer to be dynamically determined at
+  # runtime if a blk is given.
+  config.tracer { Datadog.tracer }
+
+  # <url>,<url>...;<url>,...;...
+  redis_urls = ENV['REDIS_MEMO_REDIS_URLS']
+  if redis_urls.present?
+    # Set configuration values to pass to the Redis client. If multiple
+    # configurations are passed to this method, we assume that the first config
+    # corresponds to the primary node, and subsequent configurations correspond
+    # to replica nodes.
+    config.redis = redis_urls.split(';').map do |urls|
+      urls.split(',').map do |url|
+        {
+          url: url,
+          # All timeout values are specified in seconds
+          connect_timeout: ENV['REDIS_MEMO_CONNECT_TIMEOUT']&.to_f || 0.2,
+          read_timeout: ENV['REDIS_MEMO_READ_TIMEOUT']&.to_f || 0.5,
+          write_timeout: ENV['REDIS_MEMO_WRITE_TIMEOUT']&.to_f || 0.5,
+          reconnect_attempts: ENV['REDIS_MEMO_RECONNECT_ATTEMPTS']&.to_i || 0,
+        }
+      end
+    end
+  end
+
+  if !Rails.env.test?
+    thread_pool = Concurrent::ThreadPoolExecutor.new(
+      min_threads: 1,
+      max_threads: ENV['REDIS_MEMO_MAX_THREADS']&.to_i || 20,
+      max_queue: 100,
+      # If we're overwhelmed, discard the current invalidation request and
+      # retry later
+      fallback_policy: :discard,
+      auto_terminate: false,
+    )
+
+    # A handler used to asynchronously perform cache writes and invalidations.
+    # If no value is provided, RedisMemo will perform these operations
+    # synchronously.
+    config.async = proc do |&blk|
+      # Skip async in rails console since the async logs would interfere with
+      # the console outputs
+      if defined?(Rails::Console)
+        blk.call
+      else
+        thread_pool.post { blk.call }
+      end
+    end
+  end
+
+  unless ENV['REDIS_MEMO_CONNECTION_POOL_SIZE'].nil?
+    # Configuration values for connecting to RedisMemo using a connection pool.
+    # It's recommended to use a connection pool in multi-threaded applications,
+    # or when an async handler is set.
+    config.connection_pool = {
+      size: ENV['REDIS_MEMO_CONNECTION_POOL_SIZE'].to_i,
+      timeout: ENV['REDIS_MEMO_CONNECTION_POOL_TIMEOUT']&.to_i || 0.2,
+    }
+  end
+
+  # Specify the global sampled percentage of the chance to call the cache
+  # validation, a value between 0 to 100, when the value is 100, it will call
+  # the handler every time the cached result does not match the uncached result
+  # You can also specify inline cache validation sample percentage by
+  # memoize_method :method, cache_validation_sample_percentage: #{value}
+  config.cache_validation_sample_percentage = ENV['REDIS_MEMO_CACHE_VALIDATION_SAMPLE_PERCENTAGE']&.to_i
+
+  # Handler called when the cached result does not match the uncached result
+  # (sampled at the `cache_validation_sample_percentage`). This might indicate
+  # that invalidation is happening too slowly or that there are incorrect
+  # dependencies specified on a cached method.
+  config.cache_out_of_date_handler = proc do |ref, method_id, args, cached_result, fresh_result|
+    ErrorReporter.notify(
+      "Cache does not match its current value: #{method_id}",
+      tags: { method_id: method_id },
+      extra: {
+        self: ref.to_s,
+        args: args,
+        cached_result: cached_result,
+        fresh_result: fresh_result,
+      },
+    )
+  end
+end

--- a/docs/wiki/Configure-RedisMemo.md
+++ b/docs/wiki/Configure-RedisMemo.md
@@ -1,3 +1,7 @@
+### A Real Example
+
+https://github.com/chanzuckerberg/redis-memo/blob/main/docs/examples/config.rb
+
 ### Options
 You can configure and set various RedisMemo options in your initializer `config/initializers/redis_memo.rb`:
 ```ruby
@@ -20,18 +24,17 @@ We highly recommend sampling at least 1% of the cached methods in production. Wh
 You can configure the cache sample validation percentage both globally or in inline method:
 
 1. To specify global validation percentage:
-    ```ruby
-    RedisMemo.configure do |config|
-
-      config.cache_validation_sample_percentage = 100
-      ...
-    end
-    ```
+```ruby
+RedisMemo.configure do |config|
+  config.cache_validation_sample_percentage = 100
+  ...
+end
+```
 
 2. To specify validation percentage in inline method:
-    ```ruby
-    memoize_method :load cache_validation_sample_percentage: 100
-    ```
+```ruby
+memoize_method :load, cache_validation_sample_percentage: 100
+```
 
 
 ### Kill switches

--- a/lib/redis_memo/options.rb
+++ b/lib/redis_memo/options.rb
@@ -132,15 +132,15 @@ class RedisMemo::Options
   # RedisMemo will perform these operations synchronously.
   attr_accessor :async
 
-  # Handler called when the cached result does not match the uncached result (sampled at the
-  # `cache_validation_sample_percentage`). This might indicate that invalidation is happening too slowly or
-  # that there are incorrect dependencies specified on a cached method.
-  attr_accessor :cache_out_of_date_handler
-
   # Specify the global sampled percentage of the chance to call the cache validation, a value between 0 to 100, when the value
   # is 100, it will call the handler every time the cached result does not match the uncached result
   # You can also specify inline cache validation sample percentage by memoize_method :method, cache_validation_sample_percentage: #{value}
   attr_accessor :cache_validation_sample_percentage
+
+  # Handler called when the cached result does not match the uncached result (sampled at the
+  # `cache_validation_sample_percentage`). This might indicate that invalidation is happening too slowly or
+  # that there are incorrect dependencies specified on a cached method.
+  attr_accessor :cache_out_of_date_handler
 
   # Passed along to the Rails {RedisCacheStore}[https://api.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html], determines whether or not to compress entries before storing
   # them. default: `true`


### PR DESCRIPTION
### Summary
This adds an example configuration, modified from the ones we have in traject, as a reference.