### PR TITLE
[doc] rdoc for cache select

### DIFF
--- a/lib/redis_memo/memoize_query/cached_select.rb
+++ b/lib/redis_memo/memoize_query/cached_select.rb
@@ -99,7 +99,7 @@ class RedisMemo::MemoizeQuery::CachedSelect
   RedisMemo::ThreadLocalVar.define :substitues
   RedisMemo::ThreadLocalVar.define :arel_bind_params
 
-  # @return [Hash] caching enabled models
+  # @return [Hash] models enabled for caching
   def self.enabled_models
     @@enabled_models
   end
@@ -161,10 +161,11 @@ class RedisMemo::MemoizeQuery::CachedSelect
   end
 
   # Extract bind params from the query by inspecting the SQL's AST recursively
+  # The bind params will be passed into the local thread variables
   # See +extract_bind_params_recurse+ for how to extract binding params recursively
   #
   # @param sql [String] SQL query
-  # @return [Boolean]
+  # @return [Boolean] indicating whether a query should be cached
   def self.extract_bind_params(sql)
     ast = RedisMemo::ThreadLocalVar.arel&.ast
     return false unless ast.is_a?(Arel::Nodes::SelectStatement)

--- a/lib/redis_memo/memoize_query/cached_select.rb
+++ b/lib/redis_memo/memoize_query/cached_select.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-#
+##
 # Inspect a SQL's AST to memoize SELECT statements
 #
 # As Rails applies additional logic on top of the rows returned from the
@@ -99,6 +99,7 @@ class RedisMemo::MemoizeQuery::CachedSelect
   RedisMemo::ThreadLocalVar.define :substitues
   RedisMemo::ThreadLocalVar.define :arel_bind_params
 
+  # @return [Hash] caching enabled models
   def self.enabled_models
     @@enabled_models
   end
@@ -113,8 +114,10 @@ class RedisMemo::MemoizeQuery::CachedSelect
       memoize_method(
         :exec_query,
         method_id: proc do |_, sql, *_args|
-          sql.gsub(/(\$\d+)/, '?')      # $1 -> ?
-             .gsub(/((, *)*\?)+/, '?')  # (?, ?, ? ...) -> (?)
+          # replace $1 with ?,
+          # and (?, ?, ? ...) with (?)
+          sql.gsub(/(\$\d+)/, '?')
+             .gsub(/((, *)*\?)+/, '?')
         end,
       ) do |_, sql, _, binds, **|
         depends_on RedisMemo::MemoizeQuery::CachedSelect.current_query_bind_params
@@ -157,6 +160,11 @@ class RedisMemo::MemoizeQuery::CachedSelect
     end
   end
 
+  # Extract bind params from the query by inspecting the SQL's AST recursively
+  # See +extract_bind_params_recurse+ for how to extract binding params recursively
+  #
+  # @param sql [String] SQL query
+  # @return [Boolean]
   def self.extract_bind_params(sql)
     ast = RedisMemo::ThreadLocalVar.arel&.ast
     return false unless ast.is_a?(Arel::Nodes::SelectStatement)
@@ -209,6 +217,10 @@ class RedisMemo::MemoizeQuery::CachedSelect
   #
   # Note: Arel::Nodes#each returns a list in post-order, and it does not step
   # into Union nodes. So we're implementing our own DFS
+  #
+  # @param node [Arel::Nodes::Node]
+  #
+  # @return [RedisMemo::MemoizeQuery::CachedSelect::BindParams]
   def self.extract_bind_params_recurse(node)
     # rubocop: disable Lint/NonLocalExitFromIterator
     bind_params = BindParams.new
@@ -343,10 +355,19 @@ class RedisMemo::MemoizeQuery::CachedSelect
     # rubocop: enable Lint/NonLocalExitFromIterator
   end
 
+  # Retrieve the model info from the table node
+  # table node is an Arel::Table object, e.g. <Arel::Table @name="sites" ...>
+  # and we can retrieve the model info by inspecting thhe table name
+  # See +RedisMemo::MemoizeQuery::memoize_table_column+ for how to construct enabled_models
+  #
+  # @params table_node [Arel::Table]
   def self.extract_binding_relation(table_node)
     enabled_models[table_node.try(:name)]
   end
 
+  #
+  # Identify whether the node has filter condition
+  #
   class NodeHasFilterCondition
     def self.===(node)
       case node


### PR DESCRIPTION
### Summary

Adding rdoc for cache select.  This is what I thought was useful when developing the features of #63, as it helps to understand the logic of parsing bind params, though this is not a file that will be used much by the users. 