### PR TITLE
[doc] Specify min Redis version 6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 # -- Gemfile --
 gem 'redis-memo'
 ```
+:warning: **Required Redis Version:** 6.0.0 ([reference](https://github.com/chanzuckerberg/redis-memo/blob/91ec911766ad072b1e003f695c35594bb31f0e67/lib/redis_memo/memoizable/bump_version.lua#L14-L16))
 ## Usage
 ### Cache simple ActiveRecord queries
 In the `User` model:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 # -- Gemfile --
 gem 'redis-memo'
 ```
-:warning: **Required Redis Version:** 6.0.0 ([reference](https://github.com/chanzuckerberg/redis-memo/blob/91ec911766ad072b1e003f695c35594bb31f0e67/lib/redis_memo/memoizable/bump_version.lua#L14-L16))
+:warning: **Required Redis Version:** >= 6.0.0 ([reference](https://github.com/chanzuckerberg/redis-memo/blob/91ec911766ad072b1e003f695c35594bb31f0e67/lib/redis_memo/memoizable/bump_version.lua#L14-L16))
 ## Usage
 ### Cache simple ActiveRecord queries
 In the `User` model:


### PR DESCRIPTION
Just noticed we didn't say anything about the min Redis version in the README file. This adds it.


We can also check the min Redis version in runtime (raise an error if the Redis version is too old) but that might be an overkill assuming users would read the README page first. (and might be too strict, since it's still fine on old Redis versions if it does not run out of memory)