### PR TITLE
[feature] Support max_query_dependency_size

### DIFF
--- a/lib/redis_memo/memoizable/dependency.rb
+++ b/lib/redis_memo/memoizable/dependency.rb
@@ -30,7 +30,6 @@ class RedisMemo::Memoizable::Dependency
       extracted = self.class.extract_from_relation(dependency)
       nodes.merge!(extracted.nodes)
     when RedisMemo::MemoizeQuery::CachedSelect::BindParams
-      # A private API
       dependency.params.each do |model, attrs_set|
         memo = model.redis_memo_class_memoizable
         nodes[memo.cache_key] = memo

--- a/lib/redis_memo/memoize_query/cached_select.rb
+++ b/lib/redis_memo/memoize_query/cached_select.rb
@@ -156,7 +156,7 @@ class RedisMemo::MemoizeQuery::CachedSelect
   end
 
   # Extract bind params from the query by inspecting the SQL's AST recursively
-  # The bind params will be passed into the local thread variables See
+  # The bind params will be passed into the local thread variables. See
   # +construct_bind_params_recurse+ for how to construct binding params
   # recursively.
   #

--- a/lib/redis_memo/memoize_query/cached_select/bind_params.rb
+++ b/lib/redis_memo/memoize_query/cached_select/bind_params.rb
@@ -2,47 +2,106 @@
 
 class RedisMemo::MemoizeQuery::CachedSelect
   class BindParams
-    def params
-      #
-      # Bind params is hash of sets: each key is a model class, each value is a
-      # set of hashes for memoized column conditions. Example:
-      #
-      #   {
-      #      Site => [
-      #        {name: 'a', city: 'b'},
-      #        {name: 'a', city: 'c'},
-      #        {name: 'b', city: 'b'},
-      #        {name: 'b', city: 'c'},
-      #      ],
-      #   }
-      #
-      @params ||= Hash.new do |models, model|
-        models[model] = []
-      end
+    def initialize(left = nil, right = nil, opt = nil)
+      @left = left
+      @right = right
+      @opt = opt
+      @plan = nil
     end
 
     def union(other)
       return unless other
 
-      # The tree is almost always right-heavy. Merge into the right node for better
-      # performance.
-      other.params.merge!(params) do |_, other_attrs_set, attrs_set|
-        if other_attrs_set.empty?
-          attrs_set
-        elsif attrs_set.empty?
-          other_attrs_set
-        else
-          attrs_set + other_attrs_set
-        end
-      end
-
-      other
+      self.class.new(self, other, __method__)
     end
 
     def product(other)
+      return unless other
+
+      self.class.new(self, other, __method__)
+    end
+
+    def should_cache?
+      plan!
+      return false if plan.dependency_size > RedisMemo::DefaultOptions.max_query_dependency_size
+
+      plan.model_attrs.each do |model, attrs_set|
+        return false if attrs_set.empty?
+
+        attrs_set.each do |attrs|
+          return false unless RedisMemo::MemoizeQuery
+            .memoized_columns(model)
+            .include?(attrs.keys.sort)
+        end
+      end
+
+      !plan.model_attrs.empty?
+    end
+
+    def plan!
+      self.plan = Plan.new(self)
+      return if opt.nil?
+
+      left.plan!
+      right.plan!
+      __send__(:"plan_#{opt}")
+    end
+
+    #
+    # Extracted bind params is hash of sets: each key is a model class, each
+    # value is a set of hashes for memoized column conditions. Example:
+    #
+    #   {
+    #      Site => [
+    #        {name: 'a', city: 'b'},
+    #        {name: 'a', city: 'c'},
+    #        {name: 'b', city: 'b'},
+    #        {name: 'b', city: 'c'},
+    #      ],
+    #   }
+    #
+    def extract!
+      return if opt.nil?
+
+      left.extract!
+      right.extract!
+      __send__(:"#{opt}!")
+    end
+
+    def params
+      @params ||= Hash.new do |models, model|
+        models[model] = Set.new
+      end
+    end
+
+    protected
+
+    attr_accessor :left
+    attr_accessor :right
+    attr_accessor :opt
+    attr_accessor :plan
+
+    def union_attrs_set(left, right)
+      left.merge(right) do |_, attrs_set, other_attrs_set|
+        next attrs_set if other_attrs_set.empty?
+        next other_attrs_set if attrs_set.empty?
+        attrs_set + other_attrs_set
+      end
+    end
+
+    def plan_union
+      plan.dependency_size = left.plan.dependency_size + right.plan.dependency_size
+      plan.model_attrs = union_attrs_set(left.plan.model_attrs, right.plan.model_attrs)
+    end
+
+    def union!
+      @params = union_attrs_set(left.params, right.params)
+    end
+
+    def product_attrs_set(left, right)
       #  Example:
       #
-      #  and(
+      #  product(
       #    [{a: 1}, {a: 2}],
       #    [{b: 1}, {b: 2}],
       #  )
@@ -55,73 +114,68 @@ class RedisMemo::MemoizeQuery::CachedSelect
       #    {a: 2, b: 1},
       #    {a: 2, b: 2},
       #  ]
-      return unless other
+      left.merge(right) do |_, attrs_set, other_attrs_set|
+        next attrs_set if other_attrs_set.empty?
+        next other_attrs_set if attrs_set.empty?
 
-      # The tree is almost always right-heavy. Merge into the right node for better
-      # performance.
-      params.each do |model, attrs_set|
-        next if attrs_set.empty?
-
-        # The other model does not have any conditions so far: carry the
-        # attributes over to the other node
-        if other.params[model].empty?
-          other.params[model] = attrs_set
-          next
-        end
-
-        # Distribute the current attrs into the other
-        other_attrs_set_size = other.params[model].size
-        other_attrs_set = other.params[model]
-        merged_attrs_set = Array.new(other_attrs_set_size * attrs_set.size)
-
-        attrs_set.each_with_index do |attrs, i|
-          other_attrs_set.each_with_index do |other_attrs, j|
-            k = i * other_attrs_set_size + j
-            merged_attrs = merged_attrs_set[k] = other_attrs.dup
+        # distribute the current attrs into the other
+        merged_attrs_set = Set.new
+        attrs_set.each do |attrs|
+          other_attrs_set.each do |other_attrs|
+            merged_attrs = other_attrs.dup
+            should_add = true
             attrs.each do |name, val|
-              # Conflict detected. For example:
+              # conflict detected. for example:
               #
               #   (a = 1 or b = 1) and (a = 2 or b = 2)
               #
-              #  Keep:     a = 1 and b = 2, a = 2 and b = 1
-              #  Discard:  a = 1 and a = 2, b = 1 and b = 2
+              #  keep:     a = 1 and b = 2, a = 2 and b = 1
+              #  discard:  a = 1 and a = 2, b = 1 and b = 2
               if merged_attrs.include?(name) && merged_attrs[name] != val
-                merged_attrs_set[k] = nil
+                should_add = false
                 break
               end
 
               merged_attrs[name] = val
             end
+            merged_attrs_set << merged_attrs if should_add
           end
         end
 
-        merged_attrs_set.compact!
-        other.params[model] = merged_attrs_set
-      end
-
-      other
-    end
-
-    def uniq!
-      params.each do |_, attrs_set|
-        attrs_set.uniq!
+        merged_attrs_set
       end
     end
 
-    def memoizable?
-      return false if params.empty?
+    def plan_product
+      plan.dependency_size = left.plan.dependency_size * right.plan.dependency_size
+      plan.model_attrs = product_attrs_set(left.plan.model_attrs, right.plan.model_attrs)
+    end
 
-      params.each do |model, attrs_set|
-        return false if attrs_set.empty?
+    def product!
+      @params = product_attrs_set(left.params, right.params)
+    end
 
-        attrs_set.each do |attrs|
-          return false unless RedisMemo::MemoizeQuery
-            .memoized_columns(model)
-            .include?(attrs.keys.sort)
+    class Plan
+      attr_accessor :dependency_size
+      attr_accessor :model_attrs
+
+      def initialize(bind_params)
+        @dependency_size = 0
+        @model_attrs = Hash.new do |models, model|
+          models[model] = Set.new
+        end
+
+        # An aggregated bind_params node can only obtain params by combining
+        # its children nodes
+        return if !bind_params.__send__(:opt).nil?
+
+        bind_params.params.each do |model, attrs_set|
+          @dependency_size += attrs_set.size
+          attrs_set.each do |attrs|
+            @model_attrs[model] << attrs.keys.map { |k| [k, nil] }.to_h
+          end
         end
       end
-
-      true
     end
   end
 end

--- a/lib/redis_memo/memoize_query/cached_select/bind_params.rb
+++ b/lib/redis_memo/memoize_query/cached_select/bind_params.rb
@@ -71,8 +71,8 @@ class RedisMemo::MemoizeQuery::CachedSelect
 
     # BindParams is built recursively when iterating through the Arel AST
     # nodes. BindParams represents a binary tree. Query parameters are added to
-    # the leaf nodes or the tree, and the leaf nodes are connected by
-    # operators, such as `union` (or condition) or `product` (and condition).
+    # the leaf nodes of the tree, and the leaf nodes are connected by
+    # operators, such as `union` (or conditions) or `product` (and conditions).
     attr_accessor :left
     attr_accessor :right
     attr_accessor :operator
@@ -89,17 +89,16 @@ class RedisMemo::MemoizeQuery::CachedSelect
     # for each set of dependencies without populating their actual values.
     #
     # For example, in the planning phase,
-    # ```ruby
-    # {a:nil} x {b: nil} => {a: nil, b: nil}
-    # {a:nil, b:nil} x {a: nil: b: nil} => {a: nil, b: nil}
-    # ```
+    #
+    #   {a:nil} x {b: nil} => {a: nil, b: nil}
+    #   {a:nil, b:nil} x {a: nil: b: nil} => {a: nil, b: nil}
     #
     # and in the extraction phase, that's where the # of dependency can
     # actually grow significantly:
-    # ```ruby
-    # {a: [1,2,3]} x {b: [1,2,3]} => [{a: 1, b: 1}, ....]
-    # {a:[1,2], b:[1,2]} x {a: [1,2,3]: b: [1,2,3]} => [{a: 1, b: 1}]
-    # ```
+    #
+    #   {a: [1,2,3]} x {b: [1,2,3]} => [{a: 1, b: 1}, ....]
+    #   {a:[1,2], b:[1,2]} x {a: [1,2,3]: b: [1,2,3]} => [{a: 1, b: 1}, ...]
+    #
     class Plan
       attr_accessor :dependency_size
       attr_accessor :model_attrs

--- a/lib/redis_memo/memoize_query/cached_select/bind_params.rb
+++ b/lib/redis_memo/memoize_query/cached_select/bind_params.rb
@@ -85,6 +85,7 @@ class RedisMemo::MemoizeQuery::CachedSelect
       left.merge(right) do |_, attrs_set, other_attrs_set|
         next attrs_set if other_attrs_set.empty?
         next other_attrs_set if attrs_set.empty?
+
         attrs_set + other_attrs_set
       end
     end

--- a/lib/redis_memo/options.rb
+++ b/lib/redis_memo/options.rb
@@ -19,7 +19,7 @@ class RedisMemo::Options
     global_cache_key_version: nil,
     expires_in: nil,
     max_connection_attempts: nil,
-    max_query_dependency_size: nil,
+    max_query_dependency_size: 5000,
     disable_all: false,
     disable_cached_select: false,
     disabled_models: Set.new
@@ -35,7 +35,7 @@ class RedisMemo::Options
     @global_cache_key_version = global_cache_key_version
     @expires_in = expires_in
     @max_connection_attempts = ENV['REDIS_MEMO_MAX_ATTEMPTS_PER_REQUEST']&.to_i || max_connection_attempts
-    @max_query_dependency_size = ENV['REDIS_MEMO_MAX_QUERY_DEPENDENCY_SIZE']&.to_i || max_query_dependency_size || 5000
+    @max_query_dependency_size = ENV['REDIS_MEMO_MAX_QUERY_DEPENDENCY_SIZE']&.to_i || max_query_dependency_size
     @disable_all = ENV['REDIS_MEMO_DISABLE_ALL'] == 'true' || disable_all
     @disable_cached_select = ENV['REDIS_MEMO_DISABLE_CACHED_SELECT'] == 'true' || disable_cached_select
     @disabled_models = disabled_models
@@ -164,7 +164,7 @@ class RedisMemo::Options
   # an issue with the Redis cluster itself.
   attr_accessor :max_connection_attempts
 
-  # Only cache a SQL query when the max number of dependency is smaller or equal to this number. Default at 5000.
+  # Only cache a SQL query when the max number of dependency is smaller or equal to this number. Configurable via an ENV var REDIS_MEMO_MAX_QUERY_DEPENDENCY_SIZE. Default at 5000.
   attr_accessor :max_query_dependency_size
 
   # Passed along to the Rails {RedisCacheStore}[https://api.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html], the error handler called for Redis related errors.

--- a/lib/redis_memo/options.rb
+++ b/lib/redis_memo/options.rb
@@ -19,6 +19,7 @@ class RedisMemo::Options
     global_cache_key_version: nil,
     expires_in: nil,
     max_connection_attempts: nil,
+    max_query_dependency_size: nil,
     disable_all: false,
     disable_cached_select: false,
     disabled_models: Set.new
@@ -34,6 +35,7 @@ class RedisMemo::Options
     @global_cache_key_version = global_cache_key_version
     @expires_in = expires_in
     @max_connection_attempts = ENV['REDIS_MEMO_MAX_ATTEMPTS_PER_REQUEST']&.to_i || max_connection_attempts
+    @max_query_dependency_size = ENV['REDIS_MEMO_MAX_QUERY_DEPENDENCY_SIZE']&.to_i || max_query_dependency_size || 5000
     @disable_all = ENV['REDIS_MEMO_DISABLE_ALL'] == 'true' || disable_all
     @disable_cached_select = ENV['REDIS_MEMO_DISABLE_CACHED_SELECT'] == 'true' || disable_cached_select
     @disabled_models = disabled_models
@@ -161,6 +163,9 @@ class RedisMemo::Options
   # the caching layer. This helps make RedisMemo resilient to errors and performance issues when there's
   # an issue with the Redis cluster itself.
   attr_accessor :max_connection_attempts
+
+  # Only cache a SQL query when the max number of dependency is smaller or equal to this number. Default at 5000.
+  attr_accessor :max_query_dependency_size
 
   # Passed along to the Rails {RedisCacheStore}[https://api.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html], the error handler called for Redis related errors.
   attr_accessor :redis_error_handler

--- a/lib/redis_memo/util.rb
+++ b/lib/redis_memo/util.rb
@@ -13,6 +13,12 @@ module RedisMemo::Util
     end
   end
 
+  def self.tagify_parameterized_sql(sql)
+    # replace $1 with ?,
+    # and (?, ?, ? ...) with (?)
+    sql.gsub(/(\$\d+)/, '?').gsub(/((, *)*\?)+/, '?')
+  end
+
   def self.uuid
     SecureRandom.uuid
   end

--- a/spec/memoize_query/cached_select/bind_params_spec.rb
+++ b/spec/memoize_query/cached_select/bind_params_spec.rb
@@ -1,49 +1,49 @@
 RSpec.describe RedisMemo::MemoizeQuery::CachedSelect::BindParams do
   it 'unions' do
     left = described_class.new
-    left.params[1] << {a: 1}
+    left.params[1] << { a: 1 }
 
     right = described_class.new
-    right.params[1] << {b: 2}
+    right.params[1] << { b: 2 }
 
     bp = left.union(right)
     bp.extract!
-    expect(bp.params[1].to_a).to eq([{a: 1}, {b: 2}])
+    expect(bp.params[1].to_a).to eq([{ a: 1 }, { b: 2 }])
 
-    left.params[1] << {b: 3}
+    left.params[1] << { b: 3 }
     bp.extract!
-    expect(bp.params[1].to_a).to eq([{a: 1}, {b: 3}, {b: 2}])
+    expect(bp.params[1].to_a).to eq([{ a: 1 }, { b: 3 }, { b: 2 }])
   end
 
   it 'products' do
     left = described_class.new
-    left.params[1] << {a: 1}
+    left.params[1] << { a: 1 }
 
     right = described_class.new
-    right.params[1] << {b: 2}
+    right.params[1] << { b: 2 }
 
     bp = left.product(right)
     bp.extract!
-    expect(bp.params[1].to_a).to eq([{a: 1, b: 2}])
+    expect(bp.params[1].to_a).to eq([{ a: 1, b: 2 }])
   end
 
   it 'excludes conflict query conditions' do
     left = described_class.new
-    left.params[1] << {a: 1}
-    left.params[1] << {b: 1}
+    left.params[1] << { a: 1 }
+    left.params[1] << { b: 1 }
 
     right = described_class.new
-    right.params[1] << {a: 2}
-    right.params[1] << {b: 2}
+    right.params[1] << { a: 2 }
+    right.params[1] << { b: 2 }
 
     bp = left.product(right)
     bp.extract!
-    expect(bp.params[1].to_a).to eq([{b: 2, a: 1}, {a: 2, b: 1}])
+    expect(bp.params[1].to_a).to eq([{ b: 2, a: 1 }, { a: 2, b: 1 }])
   end
 
-  it 'should not cache query with too many dependencies' do
+  it 'does not cache query with too many dependencies' do
     fake_colums = Class.new do
-      def self.include?(*args)
+      def self.include?(*_args)
         true
       end
     end
@@ -51,32 +51,32 @@ RSpec.describe RedisMemo::MemoizeQuery::CachedSelect::BindParams do
     allow(RedisMemo::MemoizeQuery).to receive(:memoized_columns).with(anything).and_return(fake_colums)
 
     left = described_class.new
-    left.params[1] << {a: 1}
+    left.params[1] << { a: 1 }
 
     right = described_class.new
-    right.params[1] << {b: 1}
+    right.params[1] << { b: 1 }
 
     bp = left.product(right)
     expect(bp.should_cache?).to eq(true)
 
     (2..11).each do |i|
-      left.params[1] << {a: i}
-      right.params[1] << {b: i}
+      left.params[1] << { a: i }
+      right.params[1] << { b: i }
     end
 
     expect(bp.should_cache?).to eq(false)
   end
 
-  it 'should not cache query with non-dependencies' do
+  it 'does not cache query with non-dependencies' do
     fake_colums = Class.new do
-      def self.include?(*args)
+      def self.include?(*_args)
         false
       end
     end
     allow(RedisMemo::MemoizeQuery).to receive(:memoized_columns).with(anything).and_return(fake_colums)
 
     left = described_class.new
-    left.params[1] << {a: 1}
+    left.params[1] << { a: 1 }
 
     expect(left.should_cache?).to eq(false)
   end

--- a/spec/memoize_query/cached_select/bind_params_spec.rb
+++ b/spec/memoize_query/cached_select/bind_params_spec.rb
@@ -1,0 +1,83 @@
+RSpec.describe RedisMemo::MemoizeQuery::CachedSelect::BindParams do
+  it 'unions' do
+    left = described_class.new
+    left.params[1] << {a: 1}
+
+    right = described_class.new
+    right.params[1] << {b: 2}
+
+    bp = left.union(right)
+    bp.extract!
+    expect(bp.params[1].to_a).to eq([{a: 1}, {b: 2}])
+
+    left.params[1] << {b: 3}
+    bp.extract!
+    expect(bp.params[1].to_a).to eq([{a: 1}, {b: 3}, {b: 2}])
+  end
+
+  it 'products' do
+    left = described_class.new
+    left.params[1] << {a: 1}
+
+    right = described_class.new
+    right.params[1] << {b: 2}
+
+    bp = left.product(right)
+    bp.extract!
+    expect(bp.params[1].to_a).to eq([{a: 1, b: 2}])
+  end
+
+  it 'excludes conflict query conditions' do
+    left = described_class.new
+    left.params[1] << {a: 1}
+    left.params[1] << {b: 1}
+
+    right = described_class.new
+    right.params[1] << {a: 2}
+    right.params[1] << {b: 2}
+
+    bp = left.product(right)
+    bp.extract!
+    expect(bp.params[1].to_a).to eq([{b: 2, a: 1}, {a: 2, b: 1}])
+  end
+
+  it 'should not cache query with too many dependencies' do
+    fake_colums = Class.new do
+      def self.include?(*args)
+        true
+      end
+    end
+    allow(RedisMemo::DefaultOptions).to receive(:max_query_dependency_size).and_return(100)
+    allow(RedisMemo::MemoizeQuery).to receive(:memoized_columns).with(anything).and_return(fake_colums)
+
+    left = described_class.new
+    left.params[1] << {a: 1}
+
+    right = described_class.new
+    right.params[1] << {b: 1}
+
+    bp = left.product(right)
+    expect(bp.should_cache?).to eq(true)
+
+    (2..11).each do |i|
+      left.params[1] << {a: i}
+      right.params[1] << {b: i}
+    end
+
+    expect(bp.should_cache?).to eq(false)
+  end
+
+  it 'should not cache query with non-dependencies' do
+    fake_colums = Class.new do
+      def self.include?(*args)
+        false
+      end
+    end
+    allow(RedisMemo::MemoizeQuery).to receive(:memoized_columns).with(anything).and_return(fake_colums)
+
+    left = described_class.new
+    left.params[1] << {a: 1}
+
+    expect(left.should_cache?).to eq(false)
+  end
+end

--- a/spec/memoize_query/cached_select/bind_params_spec.rb
+++ b/spec/memoize_query/cached_select/bind_params_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe RedisMemo::MemoizeQuery::CachedSelect::BindParams do
         true
       end
     end
-    allow(RedisMemo::DefaultOptions).to receive(:max_query_dependency_size).and_return(100)
+    allow(RedisMemo::DefaultOptions).to receive(:max_query_dependency_size).and_return(99)
     allow(RedisMemo::MemoizeQuery).to receive(:memoized_columns).with(anything).and_return(fake_colums)
 
     left = described_class.new
@@ -59,11 +59,19 @@ RSpec.describe RedisMemo::MemoizeQuery::CachedSelect::BindParams do
     bp = left.product(right)
     expect(bp.should_cache?).to eq(true)
 
-    (2..11).each do |i|
+    (2..10).each do |i|
       left.params[1] << { a: i }
       right.params[1] << { b: i }
     end
 
+    expect(bp.should_cache?).to eq(false)
+
+    allow(RedisMemo::DefaultOptions).to receive(:max_query_dependency_size).and_return(1)
+    left = described_class.new
+    left.params[0] << { a: 1 }
+    right = described_class.new
+    right.params[1] << { b: 1 }
+    bp = left.product(right)
     expect(bp.should_cache?).to eq(false)
   end
 


### PR DESCRIPTION
### Summary
This adds a feature to respect `max_query_dependency_size`.

Users might have big queries with a super big dependency list -- if we perform cross-product on those dependencies, it might create millions of entries. Thus, this adds a way to "plan" first, before actually extracting the bind_params.

This also adds a tracer span, so we can see the time spent in extracting dependies.

### Test Plan
- Added test cases