### PR TITLE
[change] Reduce logs volume

### DIFF
--- a/lib/redis_memo/redis.rb
+++ b/lib/redis_memo/redis.rb
@@ -17,12 +17,10 @@ class RedisMemo::Redis < Redis::Distributed
           if option.is_a?(Array)
             RedisMemo::Redis::WithReplicas.new(option)
           else
-            option[:logger] ||= RedisMemo::DefaultOptions.logger
             ::Redis.new(option)
           end
         end
       else
-        options[:logger] ||= RedisMemo::DefaultOptions.logger
         [::Redis.new(options)]
       end
 
@@ -49,11 +47,9 @@ class RedisMemo::Redis < Redis::Distributed
       options = orig_options.dup
       primary_option = options.shift
       @replicas = options.map do |option|
-        option[:logger] ||= RedisMemo::DefaultOptions.logger
         ::Redis.new(option)
       end
 
-      primary_option[:logger] ||= RedisMemo::DefaultOptions.logger
       super(primary_option)
     end
 


### PR DESCRIPTION
### Summary
Currently, we're printing way too many debug logs. Those logs are hardly useful to anyone unless they're developing redis-memo.

We can simply remove those Redis logs and display an overall query latency. Note the latency is an over-estmation. It includes more than just the time spent on the redis round trips

<img width="1435" alt="Screen Shot 2021-07-01 at 2 07 54 PM" src="https://user-images.githubusercontent.com/17794071/124189601-d127b000-da75-11eb-9afc-bd09664cd2c7.png">
